### PR TITLE
Remove feature: const_in_array_repeat_expressions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 #![feature(specialization)]
 #![feature(coerce_unsized)]
 #![feature(linkage)]
-#![feature(const_in_array_repeat_expressions)]
 #![feature(unsize)]
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_fn_transmute)]


### PR DESCRIPTION
This is now by default a part of Rust (see [#79270](https://github.com/rust-lang/rust/pull/79270) and [RELEASES.md](https://github.com/rust-lang/rust/blob/master/RELEASES.md)), so `rustc` complains about an unknown feature and won't build. This PR removes that declaration.