### PR TITLE
Remove usage of xargo and switch to cargo build-std

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+target = "aarch64-none-elf.json"
+
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,1 +1,0 @@
-[dependencies.alloc]

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-RUST_TARGET_PATH=$PWD RUSTFLAGS="-Z macro-backtrace" xargo build --release --target aarch64-none-elf
+cargo build --release

--- a/clean.sh
+++ b/clean.sh
@@ -1,1 +1,1 @@
-xargo clean
+cargo clean

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This should simplify quite some stuffs while building.

Still need to update the tooling around to support it