### PR TITLE
Add nx::main and nx::heap macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+**/target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 linked_list_allocator = "0.8.4"
 paste = "1.0"
 logpacket = { git = "https://github.com/aarch64-switch-rs/logpacket" }
+nx-macros = { path = "./nx-macros" }
 
 [dependencies.derivative]
 version = "2.1.1"

--- a/nx-macros/Cargo.toml
+++ b/nx-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "nx-macros"
+version = "0.1.0"
+authors = ["jam1garner <8260240+jam1garner@users.noreply.github.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1", features = ["full"] }
+quote = "1"

--- a/nx-macros/src/lib.rs
+++ b/nx-macros/src/lib.rs
@@ -1,0 +1,45 @@
+use proc_macro::TokenStream;
+use syn::parse_quote;
+use quote::quote;
+
+#[proc_macro_attribute]
+pub fn main(_: TokenStream, input: TokenStream) -> TokenStream {
+    let mut func = syn::parse_macro_input!(input as syn::ItemFn);
+
+    // ensure abi is extern Rust
+    func.sig.abi = Some(parse_quote!(extern "Rust"));
+
+    let ident = &func.sig.ident;
+
+    quote!(
+        // export the applied function as __nx_internal_main to be linked against by `nx` itself
+        #[export_name = "__nx_internal_main"]
+        #func
+
+        // type check the function being applied to
+        const _: extern "Rust" fn() -> ::nx::result::Result<()> = #ident;
+    ).into()
+}
+
+#[proc_macro_attribute]
+pub fn heap(_: TokenStream, input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::ItemStatic);
+
+    if input.mutability.is_none() {
+        // TODO: improve error handling
+        panic!("Heap must be marked mutable");
+    }
+
+    let ident = &input.ident;
+
+    quote!(
+        #input
+
+        #[no_mangle]
+        pub fn __initialize_heap(_hbl_heap: ::nx::util::PointerAndSize) -> ::nx::util::PointerAndSize {
+            unsafe {
+                ::nx::util::PointerAndSize::new(#ident.as_mut_ptr(), #ident.len())
+            }
+        }
+    ).into()
+}

--- a/nx-macros/src/lib.rs
+++ b/nx-macros/src/lib.rs
@@ -36,7 +36,7 @@ pub fn heap(_: TokenStream, input: TokenStream) -> TokenStream {
         #input
 
         #[no_mangle]
-        pub fn __initialize_heap(_hbl_heap: ::nx::util::PointerAndSize) -> ::nx::util::PointerAndSize {
+        pub fn __nx_initialize_heap(_hbl_heap: ::nx::util::PointerAndSize) -> ::nx::util::PointerAndSize {
             unsafe {
                 ::nx::util::PointerAndSize::new(#ident.as_mut_ptr(), #ident.len())
             }

--- a/src/crt0.rs
+++ b/src/crt0.rs
@@ -17,8 +17,8 @@ use core::ptr;
 
 // These functions must be implemented by any executable homebrew project using this crate
 extern "Rust" {
-    fn main() -> Result<()>;
-    fn initialize_heap(hbl_heap: util::PointerAndSize) -> util::PointerAndSize;
+    fn __nx_internal_main() -> Result<()>;
+    fn __initialize_heap(hbl_heap: util::PointerAndSize) -> util::PointerAndSize;
 }
 
 pub type ExitFn = fn(ResultCode) -> !;
@@ -85,7 +85,7 @@ unsafe fn __nx_crt0_entry(abi_ptr: *const hbl::AbiConfigEntry, raw_main_thread_h
     }
     
     // Initialize heap and memory allocation
-    heap = initialize_heap(heap);
+    heap = __initialize_heap(heap);
     mem::initialize(heap.address, heap.size);
 
     // Initialize version support
@@ -103,7 +103,7 @@ unsafe fn __nx_crt0_entry(abi_ptr: *const hbl::AbiConfigEntry, raw_main_thread_h
     // TODO: finish implementing CRT0
 
     // Unwrap main(), which will trigger a panic if it didn't succeed
-    main().unwrap();
+    __nx_internal_main().unwrap();
 
     // Successful exit by default
     exit(ResultSuccess::make());

--- a/src/crt0.rs
+++ b/src/crt0.rs
@@ -18,7 +18,7 @@ use core::ptr;
 // These functions must be implemented by any executable homebrew project using this crate
 extern "Rust" {
     fn __nx_internal_main() -> Result<()>;
-    fn __initialize_heap(hbl_heap: util::PointerAndSize) -> util::PointerAndSize;
+    fn __nx_initialize_heap(hbl_heap: util::PointerAndSize) -> util::PointerAndSize;
 }
 
 pub type ExitFn = fn(ResultCode) -> !;
@@ -85,7 +85,7 @@ unsafe fn __nx_crt0_entry(abi_ptr: *const hbl::AbiConfigEntry, raw_main_thread_h
     }
     
     // Initialize heap and memory allocation
-    heap = __initialize_heap(heap);
+    heap = __nx_initialize_heap(heap);
     mem::initialize(heap.address, heap.size);
 
     // Initialize version support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 #![feature(const_mut_refs)]
 #![macro_use]
 
+pub use nx_macros::*;
+
 // Required assembly bits
 
 global_asm!(include_str!("asm.s"));


### PR DESCRIPTION
This should help reduce some of the boilerplate needed when getting started.

Here's an example of what a getting started template looks like with the given macros:

https://github.com/jam1garner/rust-sysmodule-template/blob/with_macros/src/main.rs

This also ensure that if you use the wrong function signature, it won't be undefined behavior.

Example error:

![image](https://user-images.githubusercontent.com/8260240/110258465-c00bde00-7f70-11eb-95e1-3702a96a6487.png)
