### PR TITLE
untagged_unions seems to have been removed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 #![feature(unsize)]
 #![feature(const_mut_refs)]
 #![feature(fn_traits)]
-//#![feature(untagged_unions)]
 #![feature(negative_impls)]
 #![feature(const_ptr_write)]
 #![feature(stdsimd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 #![feature(unsize)]
 #![feature(const_mut_refs)]
 #![feature(fn_traits)]
-#![feature(untagged_unions)]
+//#![feature(untagged_unions)]
 #![feature(negative_impls)]
 #![feature(const_ptr_write)]
 #![feature(stdsimd)]


### PR DESCRIPTION
``` mriley ▞ gpu-simple ▞  master ▞ cargo nx build
Building and generating NRO...
Triple: aarch64-nintendo-switch
    Updating git repository `https://github.com/aarch64-switch-rs/nx`
    Updating git repository `https://github.com/aarch64-switch-rs/logpacket`
   Compiling compiler_builtins v0.1.73
   Compiling core v0.0.0 (/home/mriley/.rustup/toolchains/nightly
   Compiling libm v0.2.2
   Compiling paste v1.0.7
   Compiling rustc-std-workspace-core v1.99.0 (/home/mriley/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/home/mriley/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc)
   Compiling ttf-parser v0.6.2
   Compiling logpacket v0.1.0 (https://github.com/aarch64-switch-rs/logpacket#d807c993)
   Compiling static_assertions v1.1.0
   Compiling arrayvec v0.5.2
   Compiling linked_list_allocator v0.9.1
   Compiling font8x8 v0.2.7
   Compiling nx v0.1.0 (https://github.com/aarch64-switch-rs/nx#bfa3d790)
   Compiling ab_glyph_rasterizer v0.1.5
   Compiling owned_ttf_parser v0.6.0
   Compiling rusttype v0.9.2
error[E0557]: feature has been removed   ] 19/22: nx
  --> /home/mriley/.cargo/git/checkouts/nx-3560396e08328007/bfa3d79/src/lib.rs:14:12
   |
14 | #![feature(untagged_unions)]
   |            ^^^^^^^^^^^^^^^ feature has been removed
   |
   = note: unions with `Copy` and `ManuallyDrop` fields are stable; there is no intent to stabilize more


error: aborting due to previous error


    Building [======================>    ] 19/22: nx                                                                                                                                                                                                         For more information about this error, try `rustc --explain E0557`.

error: could not compile `nx` due to 2 previous errors
```