### PR TITLE
feat: Implement `Default` trate for `TouchState`

### DIFF
--- a/src/ipc/sf/hid.rs
+++ b/src/ipc/sf/hid.rs
@@ -45,7 +45,7 @@ define_bit_enum! {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 #[repr(C)]
 pub struct TouchState {
     pub delta_time: u64,


### PR DESCRIPTION
This will make it significantly easier to create the blank array needed for calling `input::Context::get_touches`