### PR TITLE
Crash fixes but slight omnibus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 paste = "1.0"
 logpacket = { git = "https://github.com/aarch64-switch-rs/logpacket" }
-linked_list_allocator = { version = "0.10.5", default-features = false, features = [ "const_mut_refs", "alloc_ref" ] }
+linked_list_allocator = { version = "0.10.5", default-features = false, features = [ "const_mut_refs", "alloc_ref", "use_spin" ] }
 arrayvec = { version = "0.7.4", default-features = false, features = [] }
 static_assertions = "1.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 paste = "1.0"
 logpacket = { git = "https://github.com/aarch64-switch-rs/logpacket" }
-linked_list_allocator = { version = "0.10.5", default-features = false, features = [ "const_mut_refs" ] }
+linked_list_allocator = { version = "0.10.5", default-features = false, features = [ "const_mut_refs", "alloc_ref" ] }
 arrayvec = { version = "0.7.4", default-features = false, features = [] }
 static_assertions = "1.1.0"
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1083,12 +1083,13 @@ impl Context {
 
 impl Drop for Context {
     /// Destroys the [`Context`], closing everything it opened when it was created
+    #[allow(unused_must_use)]
     fn drop(&mut self) {
-        let _ = self.nvdrv_service.get().close(self.nvhost_fd);
-        let _ = self.nvdrv_service.get().close(self.nvmap_fd);
-        let _ = self.nvdrv_service.get().close(self.nvhostctrl_fd);
+        self.nvdrv_service.get().close(self.nvhost_fd);
+        self.nvdrv_service.get().close(self.nvmap_fd);
+        self.nvdrv_service.get().close(self.nvhostctrl_fd);
 
-        drop(&mut core::mem::replace(&mut self.transfer_mem, Buffer::empty()));
-        let _ = svc::close_handle(self.transfer_mem_handle);
+        drop(core::mem::replace(&mut self.transfer_mem, Buffer::empty()));
+        svc::close_handle(self.transfer_mem_handle);
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,6 +1,5 @@
 //! Graphics and GPU support and utils
 
-use crate::mem::alloc::Buffer;
 use crate::result::*;
 use crate::service;
 use crate::mem;
@@ -16,7 +15,6 @@ use crate::service::vi::IManagerRootService;
 use crate::service::vi::IApplicationDisplayService;
 use crate::service::dispdrv;
 use crate::service::applet;
-use crate::svc::MemoryAttribute;
 use crate::svc::MemoryPermission;
 
 pub mod rc;
@@ -1091,11 +1089,9 @@ impl Drop for Context {
         self.nvdrv_service.get().close(self.nvmap_fd);
         self.nvdrv_service.get().close(self.nvhostctrl_fd);
         
-
         self.nvdrv_service.get().close(self.transfer_mem_handle);
         self.nvdrv_service.get().get_session().close();
         svc::close_handle(self.transfer_mem_handle).unwrap();
-        svc::transfer_memory_wait_for_permission(self.transfer_mem.ptr,  MemoryPermission::Write());
-
+        mem::wait_for_permission(self.transfer_mem.ptr,  MemoryPermission::Write(), None);
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,5 +1,6 @@
 //! Graphics and GPU support and utils
 
+use crate::mem::alloc::Buffer;
 use crate::result::*;
 use crate::service;
 use crate::mem;
@@ -1087,7 +1088,7 @@ impl Drop for Context {
         let _ = self.nvdrv_service.get().close(self.nvmap_fd);
         let _ = self.nvdrv_service.get().close(self.nvhostctrl_fd);
 
-        self.transfer_mem.release();
+        drop(&mut core::mem::replace(&mut self.transfer_mem, Buffer::empty()));
         let _ = svc::close_handle(self.transfer_mem_handle);
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -16,6 +16,8 @@ use crate::service::vi::IManagerRootService;
 use crate::service::vi::IApplicationDisplayService;
 use crate::service::dispdrv;
 use crate::service::applet;
+use crate::svc::MemoryAttribute;
+use crate::svc::MemoryPermission;
 
 pub mod rc;
 
@@ -1088,8 +1090,18 @@ impl Drop for Context {
         self.nvdrv_service.get().close(self.nvhost_fd);
         self.nvdrv_service.get().close(self.nvmap_fd);
         self.nvdrv_service.get().close(self.nvhostctrl_fd);
+        
 
-        drop(core::mem::replace(&mut self.transfer_mem, Buffer::empty()));
-        svc::close_handle(self.transfer_mem_handle);
+        self.nvdrv_service.get().close(self.transfer_mem_handle);
+        self.nvdrv_service.get().get_session().close();
+        svc::transfer_memory_wait_for_permission(self.transfer_mem.ptr,  MemoryPermission::Write());
+
+        
+        svc::close_handle(self.transfer_mem_handle).unwrap();
+        //svc::set_memory_attribute(self.transfer_mem.ptr, self.transfer_mem.layout.size(), 0, MemoryAttribute::None());
+        //svc::set_memory_permission(self.transfer_mem.ptr, self.transfer_mem.layout.size(), MemoryPermission::Read() | MemoryPermission::Write()).unwrap();
+        // SAFETY: transfer_mem is immediately dropped after, so it can't be reused.
+        unsafe {self.transfer_mem.release()};
+
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1094,14 +1094,8 @@ impl Drop for Context {
 
         self.nvdrv_service.get().close(self.transfer_mem_handle);
         self.nvdrv_service.get().get_session().close();
-        svc::transfer_memory_wait_for_permission(self.transfer_mem.ptr,  MemoryPermission::Write());
-
-        
         svc::close_handle(self.transfer_mem_handle).unwrap();
-        //svc::set_memory_attribute(self.transfer_mem.ptr, self.transfer_mem.layout.size(), 0, MemoryAttribute::None());
-        //svc::set_memory_permission(self.transfer_mem.ptr, self.transfer_mem.layout.size(), MemoryPermission::Read() | MemoryPermission::Write()).unwrap();
-        // SAFETY: transfer_mem is immediately dropped after, so it can't be reused.
-        unsafe {self.transfer_mem.release()};
+        svc::transfer_memory_wait_for_permission(self.transfer_mem.ptr,  MemoryPermission::Write());
 
     }
 }

--- a/src/gpu/ioctl.rs
+++ b/src/gpu/ioctl.rs
@@ -84,7 +84,7 @@ pub enum AllocFlags {
 pub struct NvMapAlloc {
     /// The input handle
     pub handle: u32,
-    /// The input heao mask
+    /// The input heap mask
     pub heap_mask: u32,
     /// The input [`AllocFlags`]
     pub flags: AllocFlags,
@@ -123,6 +123,35 @@ pub struct NvMapGetId {
 impl Ioctl for NvMapGetId {
     fn get_id() -> nv::IoctlId {
         nv::IoctlId::NvMapGetId
+    }
+
+    fn get_fd() -> IoctlFd {
+        IoctlFd::NvMap
+    }
+}
+
+/// Represents the `Free` command for [`NvMap`][`IoctlFd::NvMap`] fd
+/// 
+/// See <https://switchbrew.org/wiki/NV_services#NVMAP_IOC_FREE>
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[repr(C)]
+pub struct NvMapFree {
+    /// The input handle
+    pub handle: u32,
+    /// padding to guarantee 8-byte offset for address
+    pub _pad: u32,
+    /// address of the buffer
+    pub address: usize,
+    /// size of the buffer
+    pub size: u32,
+    /// flags for the opened handle (1 if requested as uncached)
+    pub flags: u32
+
+}
+
+impl Ioctl for NvMapFree {
+    fn get_id() -> nv::IoctlId {
+        nv::IoctlId::NvMapFree
     }
 
     fn get_fd() -> IoctlFd {

--- a/src/gpu/surface.rs
+++ b/src/gpu/surface.rs
@@ -305,7 +305,9 @@ impl Drop for Surface {
         let buf_size = self.buffer_count as usize * self.single_buffer_size;
         svc::set_memory_attribute(self.buffer_data.ptr, buf_size, 0, svc::MemoryAttribute::None());
         
-        drop(core::mem::replace(&mut self.buffer_data, Buffer::empty()));
+        // we know we can call release here because we're in the Drop impl
+        unsafe {self.buffer_data.release()};
+
         (self.layer_destroy_fn)(self.layer_id, self.application_display_service.clone());
 
         self.application_display_service.get().close_display(self.display_id);

--- a/src/gpu/surface.rs
+++ b/src/gpu/surface.rs
@@ -254,6 +254,18 @@ impl Surface {
         system_display_service.get().set_layer_visibility(visible, self.layer_id)
     }
 
+    /// Adds a layer visibility stack
+    /// 
+    /// The Management display server maintains a stack of visible layers. This allows us to order our layer relative to other elements (e.g. visible or invisible to screenshots/recordings)
+    /// 
+    /// # Atguments
+    /// 
+    /// * `stack_type_id`: the type of layer to add to the visibility stack
+    pub fn push_layer_stack(&mut self, stack_type_id: vi::LayerStackId) -> Result<()> {
+        let manager_display_service = self.application_display_service.get().get_manager_display_service()?;
+        manager_display_service.get().add_to_layer_stack(stack_type_id,self.layer_id)
+    }
+
     /// Waits for the buffer event
     /// 
     /// # Arguments

--- a/src/ipc/sf/vi.rs
+++ b/src/ipc/sf/vi.rs
@@ -1,5 +1,3 @@
-use core::default;
-
 use crate::result::*;
 use crate::ipc::sf;
 use crate::mem;

--- a/src/ipc/sf/vi.rs
+++ b/src/ipc/sf/vi.rs
@@ -1,3 +1,5 @@
+use core::default;
+
 use crate::result::*;
 use crate::ipc::sf;
 use crate::mem;
@@ -26,10 +28,25 @@ pub enum DisplayServiceMode {
     Privileged = 1
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[repr(u32)]
+pub enum LayerStackId {
+    #[default]
+    Default,
+    Lcd,
+    Screenshot,
+    Recording,
+    LastFrame,
+    Arbitrary,
+    ApplicationForDebug,
+    Null
+}
+
 ipc_sf_define_interface_trait! {
     trait IManagerDisplayService {
         create_managed_layer [2010, version::VersionInterval::all()]: (flags: LayerFlags, display_id: DisplayId, aruid: applet::AppletResourceUserId) => (id: LayerId);
         destroy_managed_layer [2011, version::VersionInterval::all()]: (id: LayerId) => ();
+        add_to_layer_stack [6000, version::VersionInterval::all()]: (stack: LayerStackId, layer: LayerId) => ();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 #![feature(negative_impls)]
 #![feature(const_ptr_write)]
 #![feature(const_intrinsic_copy)]
+#![feature(let_chains)]
 #![macro_use]
 
 use core::arch::global_asm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
 //! Library examples are located at this other [repository](https://github.com/aarch64-switch-rs/examples)
 
 #![no_std]
+#![feature(allocator_api)]
+#![feature(slice_ptr_get)]
 #![allow(incomplete_features)]
 #![allow(non_snake_case)]
 #![feature(adt_const_params)]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -36,8 +36,7 @@ impl ReferenceCount {
         if !ptr.is_null() {
             unsafe {
                 if self.holder.is_null() {
-                    self.holder = alloc::new::<u64>().unwrap();
-                    *self.holder = 1;
+                    self.holder = Box::into_raw(Box::new(1));
                 }
                 else {
                     *self.holder += 1;
@@ -53,7 +52,7 @@ impl ReferenceCount {
                 if *self.holder == 0 {
                     // We created the variable as a Box, so we destroy it the same way
                     mem::drop(Box::from_raw(ptr));
-                    alloc::delete(self.holder);
+                    mem::drop(Box::from_raw(self.holder));
                     self.holder = ptr::null_mut();
                 }
             }

--- a/src/mem/alloc.rs
+++ b/src/mem/alloc.rs
@@ -1,18 +1,15 @@
 //! Allocator implementation and definitions
 
 use crate::result::*;
-use crate::sync;
 use crate::util::PointerAndSize;
 use core::mem;
 use core::ptr;
 use core::ptr::NonNull;
-use core::result::Result as CoreResult;
 
 extern crate alloc;
 use alloc::alloc::Allocator;
 
 use alloc::alloc::Global;
-use alloc::alloc::GlobalAlloc;
 pub use alloc::alloc::Layout;
 
 pub const PAGE_ALIGNMENT: usize = 0x1000;
@@ -55,13 +52,9 @@ pub unsafe trait AllocatorEx: Allocator {
 
 unsafe impl AllocatorEx for Global {}
 
-extern crate linked_list_allocator;
-use linked_list_allocator::Heap as LinkedListAllocator;
-
 #[global_allocator]
 static GLOBAL_ALLOCATOR: linked_list_allocator::LockedHeap =
     linked_list_allocator::LockedHeap::empty();
-//static GLOBAL_ALLOCATOR: sync::Locked<LateInitAllocator> = sync::Locked::new(false, LateInitAllocator::new());
 
 /// Initializes the global allocator with the given address and size.
 /// Returns a bool to indicate if the memory was consumed by the allocator

--- a/src/mem/alloc.rs
+++ b/src/mem/alloc.rs
@@ -258,7 +258,7 @@ impl<T> Buffer<T> {
     /// Releases the [`Buffer`]
     /// 
     /// The [`Buffer`] becomes invalid after this
-    pub fn release(&mut self) {
+    fn release(&mut self) {
         unsafe {self.allocator.deallocate(NonNull::new_unchecked(self.ptr.cast()), self.layout);}
         *self = Self::empty();
     }

--- a/src/mem/alloc.rs
+++ b/src/mem/alloc.rs
@@ -5,8 +5,13 @@ use crate::util::PointerAndSize;
 use crate::sync;
 use core::ptr;
 use core::mem;
+use core::ptr::NonNull;
+use core::result::Result as CoreResult;
 
 extern crate alloc;
+use alloc::alloc::Allocator;
+
+use alloc::alloc::Global;
 use alloc::alloc::GlobalAlloc;
 pub use alloc::alloc::Layout;
 
@@ -14,29 +19,26 @@ pub const PAGE_ALIGNMENT: usize = 0x1000;
 
 pub mod rc;
 
+use alloc::alloc::AllocError;
+
+impl From<AllocError> for ResultCode {
+    fn from(_value: AllocError) -> Self {
+        ResultCode::new(rc::ResultOutOfMemory::get_value())
+    }
+}
+
 // TODO: be able to change the global allocator?
 
+
 /// Represents a heap allocator for this library
-pub trait Allocator {
-    /// Allocates memory
-    /// 
-    /// # Arguments
-    /// 
-    /// * `layout`: The memory layout
-    fn allocate(&mut self, layout: Layout) -> Result<*mut u8>;
-
-    /// Releases memory
-    /// 
-    /// # Arguments
-    /// 
-    /// * `addr`: The memory address
-    /// * `layout`: The memory layout
-    fn release(&mut self, addr: *mut u8, layout: Layout);
-
+pub unsafe trait AllocatorEx: Allocator {
     /// Allocates a new heap value
     fn new<T>(&mut self) -> Result<*mut T> {
         let layout = Layout::new::<T>();
-        self.allocate(layout).map(|ptr| ptr as *mut T)
+        match self.allocate(layout) {
+            Ok(allocation) => Ok(allocation.as_ptr().cast()),
+            Err(_) => rc::ResultOutOfMemory::make_err()
+        }
     }
 
     /// Releases a heap value
@@ -48,53 +50,90 @@ pub trait Allocator {
     /// * `t`: Heap value address
     fn delete<T>(&mut self, t: *mut T) {
         let layout = Layout::new::<T>();
-        self.release(t as *mut u8, layout);
+        unsafe {self.deallocate(NonNull::new_unchecked(t.cast()), layout)};
     }
 }
+
+unsafe impl AllocatorEx for Global{}
 
 extern crate linked_list_allocator;
 use linked_list_allocator::Heap as LinkedListAllocator;
 
-impl Allocator for LinkedListAllocator {
-    fn allocate(&mut self, layout: Layout) -> Result<*mut u8> {
-        match self.allocate_first_fit(layout) {
-            Ok(non_null_addr) => Ok(non_null_addr.as_ptr()),
-            Err(_) => rc::ResultOutOfMemory::make_err()
-        }
-    }
-
-    fn release(&mut self, addr: *mut u8, layout: Layout) {
-        if !addr.is_null() {
-            unsafe {
-                self.deallocate(ptr::NonNull::new_unchecked(addr), layout);
-            }
-        }
-    }
-}
-
 unsafe impl<A: Allocator> GlobalAlloc for sync::Locked<A> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        self.get().allocate(layout).unwrap()
+        self.get().allocate(layout).unwrap().as_ptr().as_mut_ptr()
     }
 
     unsafe fn dealloc(&self, addr: *mut u8, layout: Layout) {
-        self.get().release(addr, layout);
+        self.get().deallocate(ptr::NonNull::new_unchecked(addr), layout);
+    }
+}
+
+struct LateInitAllocator {
+    initialized: bool,
+    inner: LinkedListAllocator
+}
+
+impl LateInitAllocator {
+    const fn new() -> Self {
+        Self { initialized: false, inner: LinkedListAllocator::empty() }
+    }
+
+    unsafe fn init(&mut self, bottom: *mut u8, size: usize) {
+        assert!(!self.initialized, "Heap already initialized");
+        self.inner.init(bottom, size);
+        self.initialized = true;
+    }
+}
+
+unsafe impl Allocator for sync::Locked<LateInitAllocator> {
+    fn allocate(&self, layout: Layout) -> CoreResult<NonNull<[u8]>, AllocError> {
+        let handle = self.get();
+        // if compiled in debug mode, the allocator will panic when allocating without initialising the allocator
+        debug_assert!(handle.initialized, "Allocator not initialized");
+        // if compiled in release mode, the allocator will return an OOM error as there is no memory available for the allocator
+        if !handle.initialized {return Err(AllocError);}
+        match handle.inner.allocate_first_fit(layout) {
+            Ok(non_null_addr) => Ok(NonNull::slice_from_raw_parts(non_null_addr, layout.size())),
+            Err(_) => Err(AllocError)
+        }
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        self.get().inner.deallocate(ptr, layout);
+    }
+
+}
+
+unsafe impl GlobalAlloc for sync::Locked<LateInitAllocator> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.allocate(layout).unwrap().as_ptr().as_mut_ptr()
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.deallocate(NonNull::new_unchecked(ptr), layout)
     }
 }
 
 #[global_allocator]
-static mut G_ALLOCATOR_HOLDER: sync::Locked<LinkedListAllocator> = sync::Locked::new(false, LinkedListAllocator::empty());
-static mut G_ALLOCATOR_ENABLED: bool = false;
+static GLOBAL_ALLOCATOR: sync::Locked<LateInitAllocator> = sync::Locked::new(false, LateInitAllocator::new());
 
-/// Initializes the global allocator with the given address and size
+/// Initializes the global allocator with the given address and size.
+/// Returns a bool to indicate if the memory was consumed by the allocator
 /// 
 /// # Arguments
 /// 
 /// * `heap`: The heap address and size
-pub fn initialize(heap: PointerAndSize) {
+pub fn initialize(heap: PointerAndSize) -> bool {
     unsafe {
-        G_ALLOCATOR_HOLDER.get().init(heap.address, heap.size);
-        G_ALLOCATOR_ENABLED = true;
+        let handle = GLOBAL_ALLOCATOR.get();
+        if !handle.initialized {
+            handle.inner.init(heap.address, heap.size);
+            handle.initialized = true;
+            return true;
+        } else {
+            return false;
+        }
     }
 }
 
@@ -110,11 +149,10 @@ pub(crate) fn set_enabled(enabled: bool) {
 /// 
 /// The library may internally disable them in exceptional cases: for instance, to avoid exception handlers to allocate heap memory if the exception cause is actually an OOM situation
 pub fn is_enabled() -> bool {
-    unsafe {
-        G_ALLOCATOR_ENABLED
-    }
+        GLOBAL_ALLOCATOR.get().initialized
 }
 
+/*
 /// Allocates heap memory using the global allocator
 /// 
 /// # Arguments
@@ -124,7 +162,10 @@ pub fn is_enabled() -> bool {
 pub fn allocate(align: usize, size: usize) -> Result<*mut u8> {
     unsafe {
         let layout = Layout::from_size_align_unchecked(size, align);
-        G_ALLOCATOR_HOLDER.get().allocate(layout)
+        match GLOBAL_ALLOCATOR.get().allocate(layout){
+            Ok(p) => p.as_ptr().as_mut_ptr(),
+            err(e)
+        }.map(|p| p.as_ptr().as_mut_ptr()).ma
     }
 }
 
@@ -138,14 +179,14 @@ pub fn allocate(align: usize, size: usize) -> Result<*mut u8> {
 pub fn release(addr: *mut u8, align: usize, size: usize) {
     unsafe {
         let layout = Layout::from_size_align_unchecked(size, align);
-        G_ALLOCATOR_HOLDER.get().release(addr, layout);
+        GLOBAL_ALLOCATOR.get().release(addr, layout);
     }
 }
 
 /// Creates a new heap value using the global allocator
 pub fn new<T>() -> Result<*mut T> {
     unsafe {
-        G_ALLOCATOR_HOLDER.get().new::<T>()
+        GLOBAL_ALLOCATOR.get().new::<T>()
     }
 }
 
@@ -158,18 +199,20 @@ pub fn new<T>() -> Result<*mut T> {
 /// * `t`: The heap value
 pub fn delete<T>(t: *mut T) {
     unsafe {
-        G_ALLOCATOR_HOLDER.get().delete(t);
+        GLOBAL_ALLOCATOR.get().delete(t);
     }
 }
-
+*/
 /// Represents a wrapped and manually managed heap value
 /// 
 /// Note that a [`Buffer`] is able to hold both a single value or an array of values of the provided type
-pub struct Buffer<T> {
+pub struct Buffer<T, A: Allocator = Global> {
     /// The actual heap value
     pub ptr: *mut T,
     /// The memory's layout
-    pub layout: Layout
+    pub layout: Layout,
+    /// The allocator used to request the buffer
+    allocator: A
 }
 
 impl<T> Buffer<T> {
@@ -178,7 +221,8 @@ impl<T> Buffer<T> {
     pub const fn empty() -> Self {
         Self {
             ptr: ptr::null_mut(),
-            layout: Layout::new::<u8>() // Dummy value
+            layout: Layout::new::<u8>(), // Dummy value
+            allocator: Global
         }
     }
 
@@ -195,41 +239,52 @@ impl<T> Buffer<T> {
     /// * `align`: The align to use
     /// * `count`: The count of values to allocate
     pub fn new(align: usize, count: usize) -> Result<Self> {
-        let size = count * mem::size_of::<T>();
-        let ptr = allocate(align, size)? as *mut T;
+        let layout = Layout::from_size_align(count * mem::size_of::<T>(), align).map_err(|_| ResultCode::new(rc::ResultLayoutError::get_value()))?;
+        let allocator = Global;
+        let ptr = allocator.allocate(layout)?.as_ptr().cast();
         Ok(Self {
             ptr,
-            layout: unsafe {
-                Layout::from_size_align_unchecked(size, align)
-            }
+            layout,
+            allocator
         })
     }
 
-    /// Creates a new [`Buffer`] using a given allocator
-    /// 
-    /// # Arguments
-    /// 
-    /// * `align`: The align to use
-    /// * `count`: The count of values to allocate
-    /// * `allocator`: The allocator
-    pub fn new_alloc<A: Allocator>(align: usize, count: usize, allocator: &mut A) -> Result<Self> {
-        let size = count * mem::size_of::<T>();
-        let layout = unsafe {
-            Layout::from_size_align_unchecked(size, align)
-        };
-        let ptr = allocator.allocate(layout)? as *mut T;
-
-        Ok(Self {
-            ptr,
-            layout
-        })
+    pub fn into_raw(self) -> *mut [T] {
+        unsafe {
+            core::slice::from_raw_parts_mut(self.ptr, self.layout.size() / mem::size_of::<T>()) as *mut [T]
+        }
     }
 
     /// Releases the [`Buffer`]
     /// 
     /// The [`Buffer`] becomes invalid after this
     pub fn release(&mut self) {
-        release(self.ptr as *mut u8, self.layout.align(), self.layout.size());
+        unsafe {self.allocator.deallocate(NonNull::new_unchecked(self.ptr.cast()), self.layout);}
         *self = Self::empty();
+    }
+}
+
+impl<T, A: Allocator> Buffer<T, A> {
+    /// Creates a new [`Buffer`] using a given allocator
+    /// 
+    /// # Arguments
+    /// 
+    /// * `align`: The align to use
+    /// * `count`: The count of values to allocate
+    /// * `allocator`: The allocator to use
+    pub fn new_in(align: usize, count: usize, allocator: A) -> Result<Self> {
+        let layout = Layout::from_size_align(count * mem::size_of::<T>(), align).map_err(|_| ResultCode::new(rc::ResultLayoutError::get_value()))?;
+        let ptr = allocator.allocate(layout)?.as_ptr().cast();
+        Ok(Self {
+            ptr,
+            layout,
+            allocator
+        })
+    }
+}
+
+impl<T, A: Allocator> Drop for Buffer<T, A> {
+    fn drop(&mut self) {
+        unsafe {self.allocator.deallocate(NonNull::new_unchecked(self.ptr.cast()), self.layout);}
     }
 }

--- a/src/mem/alloc.rs
+++ b/src/mem/alloc.rs
@@ -1,10 +1,10 @@
 //! Allocator implementation and definitions
 
 use crate::result::*;
-use crate::util::PointerAndSize;
 use crate::sync;
-use core::ptr;
+use crate::util::PointerAndSize;
 use core::mem;
+use core::ptr;
 use core::ptr::NonNull;
 use core::result::Result as CoreResult;
 
@@ -42,19 +42,19 @@ pub unsafe trait AllocatorEx: Allocator {
     }
 
     /// Releases a heap value
-    /// 
+    ///
     /// The value must have been created using [`Allocator::new`]
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `t`: Heap value address
     fn delete<T>(&mut self, t: *mut T) {
         let layout = Layout::new::<T>();
-        unsafe {self.deallocate(NonNull::new_unchecked(t.cast()), layout)};
+        unsafe { self.deallocate(NonNull::new_unchecked(t.cast()), layout) };
     }
 }
 
-unsafe impl AllocatorEx for Global{}
+unsafe impl AllocatorEx for Global {}
 
 extern crate linked_list_allocator;
 use linked_list_allocator::Heap as LinkedListAllocator;
@@ -65,18 +65,22 @@ unsafe impl<A: Allocator> GlobalAlloc for sync::Locked<A> {
     }
 
     unsafe fn dealloc(&self, addr: *mut u8, layout: Layout) {
-        self.get().deallocate(ptr::NonNull::new_unchecked(addr), layout);
+        self.get()
+            .deallocate(ptr::NonNull::new_unchecked(addr), layout);
     }
 }
 
 struct LateInitAllocator {
     initialized: bool,
-    inner: LinkedListAllocator
+    inner: LinkedListAllocator,
 }
 
 impl LateInitAllocator {
     const fn new() -> Self {
-        Self { initialized: false, inner: LinkedListAllocator::empty() }
+        Self {
+            initialized: false,
+            inner: LinkedListAllocator::empty(),
+        }
     }
 
     unsafe fn init(&mut self, bottom: *mut u8, size: usize) {
@@ -92,17 +96,18 @@ unsafe impl Allocator for sync::Locked<LateInitAllocator> {
         // if compiled in debug mode, the allocator will panic when allocating without initialising the allocator
         debug_assert!(handle.initialized, "Allocator not initialized");
         // if compiled in release mode, the allocator will return an OOM error as there is no memory available for the allocator
-        if !handle.initialized {return Err(AllocError);}
+        if !handle.initialized {
+            return Err(AllocError);
+        }
         match handle.inner.allocate_first_fit(layout) {
             Ok(non_null_addr) => Ok(NonNull::slice_from_raw_parts(non_null_addr, layout.size())),
-            Err(_) => Err(AllocError)
+            Err(_) => Err(AllocError),
         }
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         self.get().inner.deallocate(ptr, layout);
     }
-
 }
 
 unsafe impl GlobalAlloc for sync::Locked<LateInitAllocator> {
@@ -116,95 +121,35 @@ unsafe impl GlobalAlloc for sync::Locked<LateInitAllocator> {
 }
 
 #[global_allocator]
-static GLOBAL_ALLOCATOR: sync::Locked<LateInitAllocator> = sync::Locked::new(false, LateInitAllocator::new());
+static GLOBAL_ALLOCATOR: linked_list_allocator::LockedHeap =
+    linked_list_allocator::LockedHeap::empty();
+//static GLOBAL_ALLOCATOR: sync::Locked<LateInitAllocator> = sync::Locked::new(false, LateInitAllocator::new());
 
 /// Initializes the global allocator with the given address and size.
 /// Returns a bool to indicate if the memory was consumed by the allocator
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `heap`: The heap address and size
 pub fn initialize(heap: PointerAndSize) -> bool {
     unsafe {
-        let handle = GLOBAL_ALLOCATOR.get();
-        if !handle.initialized {
-            handle.inner.init(heap.address, heap.size);
-            handle.initialized = true;
-            return true;
-        } else {
-            return false;
-        }
-    }
+        GLOBAL_ALLOCATOR
+            .lock()
+            .init(heap.address, heap.size)
+    };
+    return false;
 }
 
-/*
-pub(crate) fn set_enabled(enabled: bool) {
-    unsafe {
-        G_ALLOCATOR_ENABLED = enabled;
-    }
-}
-*/
 
 /// Gets whether heap allocations are enabled
-/// 
+///
 /// The library may internally disable them in exceptional cases: for instance, to avoid exception handlers to allocate heap memory if the exception cause is actually an OOM situation
 pub fn is_enabled() -> bool {
-        GLOBAL_ALLOCATOR.get().initialized
+    false //GLOBAL_ALLOCATOR.get().initialized
 }
 
-/*
-/// Allocates heap memory using the global allocator
-/// 
-/// # Arguments
-/// 
-/// * `align`: The memory alignment
-/// * `size`: The memory size
-pub fn allocate(align: usize, size: usize) -> Result<*mut u8> {
-    unsafe {
-        let layout = Layout::from_size_align_unchecked(size, align);
-        match GLOBAL_ALLOCATOR.get().allocate(layout){
-            Ok(p) => p.as_ptr().as_mut_ptr(),
-            err(e)
-        }.map(|p| p.as_ptr().as_mut_ptr()).ma
-    }
-}
-
-/// Releases allocated memory
-/// 
-/// # Arguments
-/// 
-/// * `addr`: The memory address
-/// * `align`: The memory alignment
-/// * `size`: The memory size
-pub fn release(addr: *mut u8, align: usize, size: usize) {
-    unsafe {
-        let layout = Layout::from_size_align_unchecked(size, align);
-        GLOBAL_ALLOCATOR.get().release(addr, layout);
-    }
-}
-
-/// Creates a new heap value using the global allocator
-pub fn new<T>() -> Result<*mut T> {
-    unsafe {
-        GLOBAL_ALLOCATOR.get().new::<T>()
-    }
-}
-
-/// Deletes a heap value
-/// 
-/// The value must have been created using the global allocator
-/// 
-/// # Arguments
-/// 
-/// * `t`: The heap value
-pub fn delete<T>(t: *mut T) {
-    unsafe {
-        GLOBAL_ALLOCATOR.get().delete(t);
-    }
-}
-*/
 /// Represents a wrapped and manually managed heap value
-/// 
+///
 /// Note that a [`Buffer`] is able to hold both a single value or an array of values of the provided type
 pub struct Buffer<T, A: Allocator = Global> {
     /// The actual heap value
@@ -212,7 +157,7 @@ pub struct Buffer<T, A: Allocator = Global> {
     /// The memory's layout
     pub layout: Layout,
     /// The allocator used to request the buffer
-    allocator: A
+    allocator: A,
 }
 
 impl<T> Buffer<T> {
@@ -222,7 +167,7 @@ impl<T> Buffer<T> {
         Self {
             ptr: ptr::null_mut(),
             layout: Layout::new::<u8>(), // Dummy value
-            allocator: Global
+            allocator: Global,
         }
     }
 
@@ -233,58 +178,70 @@ impl<T> Buffer<T> {
     }
 
     /// Creates a new [`Buffer`] using the global allocator
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `align`: The align to use
     /// * `count`: The count of values to allocate
     pub fn new(align: usize, count: usize) -> Result<Self> {
-        let layout = Layout::from_size_align(count * mem::size_of::<T>(), align).map_err(|_| ResultCode::new(rc::ResultLayoutError::get_value()))?;
+        let layout = Layout::from_size_align(count * mem::size_of::<T>(), align)
+            .map_err(|_| ResultCode::new(rc::ResultLayoutError::get_value()))?;
         let allocator = Global;
         let ptr = allocator.allocate(layout)?.as_ptr().cast();
         Ok(Self {
             ptr,
             layout,
-            allocator
+            allocator,
         })
     }
 
     pub fn into_raw(self) -> *mut [T] {
         unsafe {
-            core::slice::from_raw_parts_mut(self.ptr, self.layout.size() / mem::size_of::<T>()) as *mut [T]
+            core::slice::from_raw_parts_mut(self.ptr, self.layout.size() / mem::size_of::<T>())
+                as *mut [T]
         }
     }
 
     /// Releases the [`Buffer`]
-    /// 
+    ///
     /// The [`Buffer`] becomes invalid after this
-    fn release(&mut self) {
-        unsafe {self.allocator.deallocate(NonNull::new_unchecked(self.ptr.cast()), self.layout);}
-        *self = Self::empty();
+    pub unsafe fn release(&mut self) {
+        if self.is_valid() {
+            self.allocator
+                .deallocate(NonNull::new_unchecked(self.ptr.cast()), self.layout);
+            self.ptr = core::ptr::null_mut();
+        }
+        
     }
 }
 
 impl<T, A: Allocator> Buffer<T, A> {
     /// Creates a new [`Buffer`] using a given allocator
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `align`: The align to use
     /// * `count`: The count of values to allocate
     /// * `allocator`: The allocator to use
     pub fn new_in(align: usize, count: usize, allocator: A) -> Result<Self> {
-        let layout = Layout::from_size_align(count * mem::size_of::<T>(), align).map_err(|_| ResultCode::new(rc::ResultLayoutError::get_value()))?;
+        let layout = Layout::from_size_align(count * mem::size_of::<T>(), align)
+            .map_err(|_| ResultCode::new(rc::ResultLayoutError::get_value()))?;
         let ptr = allocator.allocate(layout)?.as_ptr().cast();
         Ok(Self {
             ptr,
             layout,
-            allocator
+            allocator,
         })
     }
 }
 
 impl<T, A: Allocator> Drop for Buffer<T, A> {
     fn drop(&mut self) {
-        unsafe {self.allocator.deallocate(NonNull::new_unchecked(self.ptr.cast()), self.layout);}
+        if !self.ptr.is_null() {
+            unsafe {
+                self.allocator
+                    .deallocate(NonNull::new_unchecked(self.ptr.cast()), self.layout);
+            }
+        }
     }
 }

--- a/src/mem/alloc/rc.rs
+++ b/src/mem/alloc/rc.rs
@@ -1,7 +1,5 @@
 //! Allocation-specific result definitions
 
-use core::alloc::LayoutError;
-
 use crate::rc;
 
 pub const RESULT_SUBMODULE: u32 = 1000;

--- a/src/mem/alloc/rc.rs
+++ b/src/mem/alloc/rc.rs
@@ -1,9 +1,12 @@
 //! Allocation-specific result definitions
 
+use core::alloc::LayoutError;
+
 use crate::rc;
 
 pub const RESULT_SUBMODULE: u32 = 1000;
 
 result_define_subgroup!(rc::RESULT_MODULE, RESULT_SUBMODULE => {
-    OutOfMemory: 1
+    OutOfMemory: 1,
+    LayoutError: 2
 });

--- a/src/rrt0.rs
+++ b/src/rrt0.rs
@@ -321,11 +321,12 @@ unsafe extern "C" fn __nx_rrt0_entry(arg0: usize, arg1: usize) {
         exception_entry(exc_type, stack_top);
     }
     else {
-        // TODO: why does this return the address to __nx_rrt0_entry instead of actually _start?
-        // Since it's a valid .text address anyway, use QueryMemory SVC to find the actual start
+        // We actually want `_start` which is at the start of the .text region, but we don't know if
+        // it will be close enough to support lookup via `adr`.
+        // Since this function is in `.text` anyway, use QueryMemory SVC to find the actual start
         let self_base_address: *const u8;
         asm!(
-            "adr {}, _start",
+            "adr {}, __nx_rrt0_entry",
             out(reg) self_base_address
         );
 

--- a/src/service/vi.rs
+++ b/src/service/vi.rs
@@ -18,6 +18,10 @@ impl IManagerDisplayService for ManagerDisplayService {
     fn destroy_managed_layer(&mut self, id: LayerId) -> Result<()> {
         ipc_client_send_request_command!([self.session.object_info; 2011] (id) => ())
     }
+
+    fn add_to_layer_stack(&mut self,stack:LayerStackId,layer:LayerId) -> crate::result::Result<()> {
+        ipc_client_send_request_command!([self.session.object_info; 6000] (stack, layer) => ())
+    }
 }
 
 ipc_client_define_object_default!(SystemDisplayService);

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -1,7 +1,6 @@
 use crate::ipc::sf::ncm;
 use crate::result::*;
 use crate::arm;
-use crate::thread;
 use crate::util;
 use crate::version;
 use core::ptr;
@@ -378,19 +377,6 @@ pub fn create_transfer_memory(address: Address, size: Size, permissions: MemoryP
         let rc = __nx_svc_create_transfer_memory(&mut handle, address, size, permissions);
         pack(rc, handle)
     }
-}
-
-#[inline(always)]
-pub fn transfer_memory_wait_for_permission(address: Address, permissions: MemoryPermission) -> Result<()> {
-
-    loop {
-        let (memory, _) = query_memory(address)?;
-        if memory.permission.contains(permissions) {
-            break;
-        }
-        crate::thread::sleep(100000);
-    }
-    Ok(())
 }
 
 #[inline(always)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -217,7 +217,7 @@ impl<'a> Drop for ScopedLock<'a> {
 }
 
 /// Represents a value whose access is controlled by an inner [`Mutex`]
-pub struct Locked<T> {
+pub struct Locked<T: ?Sized> {
     lock_cell: UnsafeCell<Mutex>,
     object_cell: UnsafeCell<T>,
 }
@@ -271,3 +271,6 @@ impl<T: Copy> Locked<T> {
         obj_copy
     }
 }
+
+unsafe impl<T: ?Sized + Send> Sync for Locked<T> {}
+unsafe impl<T: ?Sized + Send> Send for Locked<T> {}

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -162,7 +162,7 @@ impl Thread {
     /// * `entry`: The entrypoint function, taking args
     /// * `args`: The entrypoint arguments
     /// * `name`: The desired thread name
-    /// * `stack`: The stack address
+    /// * `stack`: The stack address. SAFETY: Must live as long as the thread is running
     /// * `stack_size`: The stack size
     pub fn new_with_stack<T: Copy, F: 'static + Fn(&T)>(entry: F, args: &T, name: &str, stack: *mut u8, stack_size: usize) -> Result<Self> {
         result_return_unless!(!stack.is_null(), rc::ResultInvalidStack);
@@ -192,7 +192,7 @@ impl Thread {
     }
     /// Creates a new [`Thread`] with an entrypoint + args, name and stack
     /// 
-    /// Same as calling [`Thread::new_with_stack`] but with the stack being automatically allocated from heap
+    /// Same as calling [`Thread::new_with_stack`] but with the stack a pre-allocated slice
     /// 
     /// Note that it needs to be initialized ([`Thread::initialize()`]) before being started ([`Thread::start()`])
     /// 
@@ -201,7 +201,7 @@ impl Thread {
     /// * `entry`: The entrypoint function, taking args
     /// * `args`: The entrypoint arguments
     /// * `name`: The desired thread name
-    /// * `stack`: The pre-allocated stack memory for the thread. SAFETY: Must live as long as the thread is running
+    /// * `stack`: The pre-allocated stack memory for the thread
     pub fn new_with_buffer<T: Copy, F: 'static + Fn(&T)>(entry: F, args: &T, name: &str, stack: &mut [u8]) -> Result<Self> {
         let thread_entry = ThreadEntry::new(thread_entry_impl::<T, F>, entry, args);
         Self::new_impl(svc::INVALID_HANDLE, ThreadState::NotInitialized, name, stack.as_mut_ptr(), stack.len(), false, Some(thread_entry))


### PR DESCRIPTION
This refactor is aimed at fixing crashes found while testing the `gpu-simple` example applet.

The following changes have been made:

1. made the allocator thread safe using `linked_list_allocator`'s `LockedHeap`. This uses a spinlock, so it should be refactored again at some point in the future as spinlocks are bad for performance under contention.
2. Changes a number of calls to `nx::alloc::{allocate, dealocate}` to using `Global` and the `Allocator` API. This should allow easier refactoring to allow consumers to bring their own allocators - I even have a PoC in a branch of my fork.
3. Fixes a semi-RNG bug in the rust runtime that causes a link failure when two symbols are too far apart.
4. Fix crashes due to memory handling errors in `gpu::Context` and `surface::Surface` where memory is handed to the kernel, and not reclaimed.
5. Add `viAddToLayerStack` because I need it for a project, but I added it first so it's a pain to remove. This can be cherry-picked out.