### PR TITLE
Update nfp the NFP API definitions.

### DIFF
--- a/src/ipc/sf/nfp.rs
+++ b/src/ipc/sf/nfp.rs
@@ -219,6 +219,7 @@ pub trait User {
     fn initialize(
         &self,
         aruid: applet::AppletResourceUserId,
+        _reserved: u64,
         mcu_data: sf::InMapAliasBuffer<McuVersionData>,
     );
     #[ipc_rid(1)]
@@ -304,8 +305,7 @@ pub trait User {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
-pub trait UserManager {
+pub trait UserManagerService {
     #[ipc_rid(0)]
     #[return_session]
     fn create_user_interface(&self) -> User;
@@ -315,14 +315,14 @@ pub trait UserManager {
 #[default_client]
 pub trait System {
     #[ipc_rid(0)]
-    fn initialize_system(
+    fn initialize(
         &self,
         aruid: applet::AppletResourceUserId,
         _reserved: u64,
         mcu_data: sf::InMapAliasBuffer<McuVersionData>,
     );
     #[ipc_rid(1)]
-    fn finalize_system(&self);
+    fn finalize(&self);
     #[ipc_rid(2)]
     fn list_devices(&self, out_devices: sf::OutPointerBuffer<DeviceHandle>) -> u32;
     #[ipc_rid(3)]
@@ -402,8 +402,7 @@ pub trait System {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
-pub trait SystemManager {
+pub trait SystemManagerService {
     #[ipc_rid(0)]
     #[return_session]
     fn create_system_interface(&self) -> System;
@@ -413,13 +412,14 @@ pub trait SystemManager {
 #[default_client]
 pub trait Debug {
     #[ipc_rid(0)]
-    fn initialize_debug(
+    fn initialize(
         &self,
         aruid: applet::AppletResourceUserId,
+        _reserved: u64,
         mcu_data: sf::InMapAliasBuffer<McuVersionData>,
     );
     #[ipc_rid(1)]
-    fn finalize_debug(&self);
+    fn finalize(&self);
     #[ipc_rid(2)]
     fn list_devices(&self, out_devices: sf::OutPointerBuffer<DeviceHandle>) -> u32;
     #[ipc_rid(3)]
@@ -550,8 +550,7 @@ pub trait Debug {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
-pub trait DebugManager {
+pub trait DebugManagerService {
     #[ipc_rid(0)]
     #[return_session]
     fn create_debug_interface(&self) -> Debug;

--- a/src/ipc/sf/nfp.rs
+++ b/src/ipc/sf/nfp.rs
@@ -219,7 +219,7 @@ pub trait User {
     fn initialize(
         &self,
         aruid: applet::AppletResourceUserId,
-        _reserved: u64,
+        process_id: sf::ProcessId,
         mcu_data: sf::InMapAliasBuffer<McuVersionData>,
     );
     #[ipc_rid(1)]
@@ -318,7 +318,7 @@ pub trait System {
     fn initialize(
         &self,
         aruid: applet::AppletResourceUserId,
-        _reserved: u64,
+        process_id: sf::ProcessId,
         mcu_data: sf::InMapAliasBuffer<McuVersionData>,
     );
     #[ipc_rid(1)]
@@ -415,7 +415,7 @@ pub trait Debug {
     fn initialize(
         &self,
         aruid: applet::AppletResourceUserId,
-        _reserved: u64,
+        process_id: sf::ProcessId,
         mcu_data: sf::InMapAliasBuffer<McuVersionData>,
     );
     #[ipc_rid(1)]

--- a/src/service/nfp.rs
+++ b/src/service/nfp.rs
@@ -4,7 +4,16 @@ use crate::service;
 
 pub use crate::ipc::sf::nfp::*;
 
-impl service::IService for UserManager {
+ipc_client_define_client_default!(UserManagerService);
+impl IUserManagerServiceClient for UserManagerService {}
+
+ipc_client_define_client_default!(DebugManagerService);
+impl IDebugManagerServiceClient for DebugManagerService {}
+
+ipc_client_define_client_default!(SystemManagerService);
+impl ISystemManagerServiceClient for SystemManagerService {}
+
+impl service::IService for UserManagerService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("nfp:user")
     }
@@ -18,7 +27,7 @@ impl service::IService for UserManager {
     }
 }
 
-impl service::IService for SystemManager {
+impl service::IService for SystemManagerService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("nfp:sys")
     }
@@ -32,7 +41,7 @@ impl service::IService for SystemManager {
     }
 }
 
-impl service::IService for DebugManager {
+impl service::IService for DebugManagerService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("nfp:dbg")
     }


### PR DESCRIPTION
This renames the IService implementors in line with changes to other services. It also adds the _reserved u64 argument to two of the services where it was missing.