### PR TITLE
Unify naming of IPC interfaces and client names where the clients implement `IService`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nx"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["XorTroll", "Pantsman0"]
 edition = "2024"
 include = [

--- a/src/diag/log/fs.rs
+++ b/src/diag/log/fs.rs
@@ -6,9 +6,9 @@ use crate::result::*;
 use crate::service;
 use crate::service::fsp::srv::{self, IFileSystemProxyClient};
 
-/// Represents a logger though `FsAccessLog`s (see [`output_access_log_to_sd_card`][`srv::FileSystemProxy::output_access_log_to_sd_card`])
+/// Represents a logger though `FsAccessLog`s (see [`output_access_log_to_sd_card`][`srv::FileSystemProxyService::output_access_log_to_sd_card`])
 pub struct FsAccessLogLogger {
-    service: Result<srv::FileSystemProxy>,
+    service: Result<srv::FileSystemProxyService>,
 }
 
 impl Logger for FsAccessLogLogger {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -697,7 +697,7 @@ fn find_device_by_name(name: &str) -> Result<Arc<dyn FileSystem>> {
     rc::ResultDeviceNotFound::make_err()
 }
 
-static G_FSPSRV_SESSION: RwLock<Option<Arc<fsp::srv::FileSystemProxy>>> = RwLock::new(None);
+static G_FSPSRV_SESSION: RwLock<Option<Arc<fsp::srv::FileSystemProxyService>>> = RwLock::new(None);
 
 define_bit_enum! {
     /// Represents options for opening files
@@ -710,13 +710,13 @@ define_bit_enum! {
     }
 }
 
-/// Initializes `fsp-srv` support instantiating a [`FileSystemProxy`][`fsp::srv::FileSystemProxy`] shared object
+/// Initializes `fsp-srv` support instantiating a [`FileSystemProxyService`][`fsp::srv::FileSystemProxyService`] shared object
 #[inline]
 pub fn initialize_fspsrv_session() -> Result<()> {
     let mut guard = G_FSPSRV_SESSION.write();
     debug_assert!(guard.is_none(), "Double initializing FSP session");
     *guard = Some(Arc::new(service::new_service_object::<
-        fsp::srv::FileSystemProxy,
+        fsp::srv::FileSystemProxyService,
     >()?));
     Ok(())
 }
@@ -735,7 +735,7 @@ pub(crate) fn finalize_fspsrv_session() {
 
 /// Gets the global [`IFileSystemProxyClient`] shared object used for `fsp-srv` support
 #[inline]
-pub fn get_fspsrv_session() -> Result<Arc<fsp::srv::FileSystemProxy>> {
+pub fn get_fspsrv_session() -> Result<Arc<fsp::srv::FileSystemProxyService>> {
     G_FSPSRV_SESSION
         .read()
         .as_ref()

--- a/src/ipc/sf/applet.rs
+++ b/src/ipc/sf/applet.rs
@@ -375,8 +375,7 @@ pub trait SystemApplicationProxy {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
-pub trait AllSystemAppletProxiesService {
+pub trait AllSystemAppletProxies {
     #[ipc_rid(0)]
     #[return_session]
     fn open_application_proxy(

--- a/src/ipc/sf/fsp/srv.rs
+++ b/src/ipc/sf/fsp/srv.rs
@@ -3,7 +3,6 @@ use crate::ipc::sf;
 use super::FileSystem;
 
 #[nx_derive::ipc_trait]
-#[default_client]
 pub trait FileSystemProxy {
     #[ipc_rid(1)]
     fn set_current_process(&self, process_id: sf::ProcessId);

--- a/src/ipc/sf/ldr.rs
+++ b/src/ipc/sf/ldr.rs
@@ -4,7 +4,6 @@ use crate::version;
 use super::ncm;
 
 #[nx_derive::ipc_trait]
-#[default_client]
 pub trait ShellInterface {
     #[ipc_rid(0)]
     #[version(version::VersionInterval::to(version::Version::new(10, 2, 0)))]

--- a/src/ipc/sf/lr.rs
+++ b/src/ipc/sf/lr.rs
@@ -45,7 +45,6 @@ pub trait RegisteredLocationResolver {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
 pub trait LocationResolverManager {
     #[ipc_rid(0)]
     #[return_session]

--- a/src/ipc/sf/mii.rs
+++ b/src/ipc/sf/mii.rs
@@ -1884,7 +1884,7 @@ const_assert!(core::mem::size_of::<NfpStoreDataExtension>() == 0x8);
 
 #[nx_derive::ipc_trait]
 #[default_client]
-pub trait DatabaseService {
+pub trait MiiDatabase {
     #[ipc_rid(0)]
     fn is_updated(&self, flag: SourceFlag) -> bool;
     #[ipc_rid(1)]
@@ -1892,7 +1892,7 @@ pub trait DatabaseService {
     #[ipc_rid(2)]
     fn get_count(&self, flag: SourceFlag) -> u32;
     #[ipc_rid(4)]
-    fn get_1(&self, flag: SourceFlag, out_char_infos: sf::OutMapAliasBuffer<CharInfo>) -> u32;
+    fn get_one(&self, flag: SourceFlag, out_char_infos: sf::OutMapAliasBuffer<CharInfo>) -> u32;
     #[ipc_rid(6)]
     fn build_random(
         &self,
@@ -1903,9 +1903,8 @@ pub trait DatabaseService {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
-pub trait StaticService {
+pub trait Static {
     #[ipc_rid(0)]
     #[return_session]
-    fn get_database_service(&self, key_code: SpecialKeyCode) -> DatabaseService;
+    fn get_database_service(&self, key_code: SpecialKeyCode) -> MiiDatabase;
 }

--- a/src/ipc/sf/ncm.rs
+++ b/src/ipc/sf/ncm.rs
@@ -232,7 +232,6 @@ pub trait ContentMetaDatabase {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
 pub trait ContentManager {
     #[ipc_rid(0)]
     #[return_session]

--- a/src/ipc/sf/nfp.rs
+++ b/src/ipc/sf/nfp.rs
@@ -305,7 +305,7 @@ pub trait User {
 }
 
 #[nx_derive::ipc_trait]
-pub trait UserManagerService {
+pub trait UserManager {
     #[ipc_rid(0)]
     #[return_session]
     fn create_user_interface(&self) -> User;
@@ -402,7 +402,7 @@ pub trait System {
 }
 
 #[nx_derive::ipc_trait]
-pub trait SystemManagerService {
+pub trait SystemManager {
     #[ipc_rid(0)]
     #[return_session]
     fn create_system_interface(&self) -> System;
@@ -550,7 +550,7 @@ pub trait Debug {
 }
 
 #[nx_derive::ipc_trait]
-pub trait DebugManagerService {
+pub trait DebugManager {
     #[ipc_rid(0)]
     #[return_session]
     fn create_debug_interface(&self) -> Debug;

--- a/src/ipc/sf/pm.rs
+++ b/src/ipc/sf/pm.rs
@@ -3,14 +3,12 @@ use crate::version;
 use super::ncm;
 
 #[nx_derive::ipc_trait]
-#[default_client]
 pub trait InformationInterface {
     #[ipc_rid(0)]
     fn get_program_id(&self, process_id: u64) -> ncm::ProgramId;
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
 pub trait DebugMonitorInterface {
     #[ipc_rid(5)]
     #[version(version::VersionInterval::to(version::Version::new(4, 1, 0)))]

--- a/src/ipc/sf/psc.rs
+++ b/src/ipc/sf/psc.rs
@@ -43,8 +43,7 @@ pub trait PmModule {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
-pub trait PmService {
+pub trait Pm {
     #[ipc_rid(0)]
     #[return_session]
     fn get_pm_module(&self) -> PmModule;

--- a/src/ipc/sf/usb/hs.rs
+++ b/src/ipc/sf/usb/hs.rs
@@ -261,7 +261,6 @@ pub trait ClientIfSession {
 }
 
 #[nx_derive::ipc_trait]
-#[default_client]
 pub trait ClientRootSession {
     #[ipc_rid(0)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]

--- a/src/ipc/sf/vi.rs
+++ b/src/ipc/sf/vi.rs
@@ -1,7 +1,9 @@
 use crate::ipc::sf;
 use crate::util;
 
-use super::applet::AppletResourceUserId;
+use sf::dispdrv::{HOSBinderDriver, IHOSBinderDriverServer};
+
+use sf::applet::AppletResourceUserId;
 
 use nx_derive::{Request, Response};
 
@@ -86,7 +88,8 @@ pub trait SystemDisplay {
 #[default_client]
 pub trait ApplicationDisplay {
     #[ipc_rid(100)]
-    fn get_relay_service(&self) -> sf::dispdrv::HOSBinderDriver;
+    #[return_session]
+    fn get_relay_service(&self) -> HOSBinderDriver;
     #[ipc_rid(101)]
     #[return_session]
     fn get_system_display_service(&self) -> SystemDisplay;

--- a/src/service/applet.rs
+++ b/src/service/applet.rs
@@ -10,6 +10,9 @@ use crate::{result::*, svc};
 
 pub use crate::ipc::sf::applet::*;
 
+ipc_client_define_client_default!(AllSystemAppletProxiesService);
+impl IAllSystemAppletProxiesClient for AllSystemAppletProxiesService {}
+
 impl service::IService for AllSystemAppletProxiesService {
     fn get_name() -> sm::ServiceName {
         // we only want to

--- a/src/service/dispdrv.rs
+++ b/src/service/dispdrv.rs
@@ -4,6 +4,8 @@ use crate::service;
 
 pub use crate::ipc::sf::dispdrv::*;
 
+/// This one gets special pribileges of not being suffixed with `Service` as it is the only implementor of `IService` that
+/// can be received from a call to a different service.
 impl service::IService for HOSBinderDriver {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("dispdrv")

--- a/src/service/fsp/srv.rs
+++ b/src/service/fsp/srv.rs
@@ -5,7 +5,10 @@ use crate::service;
 
 pub use crate::ipc::sf::fsp::srv::*;
 
-impl service::IService for FileSystemProxy {
+ipc_client_define_client_default!(FileSystemProxyService);
+impl IFileSystemProxyClient for FileSystemProxyService {}
+
+impl service::IService for FileSystemProxyService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("fsp-srv")
     }

--- a/src/service/ldr.rs
+++ b/src/service/ldr.rs
@@ -4,7 +4,10 @@ use crate::service;
 
 pub use crate::ipc::sf::ldr::*;
 
-impl service::IService for ShellInterface {
+ipc_client_define_client_default!(ShellInterfaceService);
+impl IShellInterfaceClient for ShellInterfaceService {}
+
+impl service::IService for ShellInterfaceService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("ldr:shel")
     }

--- a/src/service/lr.rs
+++ b/src/service/lr.rs
@@ -3,7 +3,10 @@ use crate::service;
 
 pub use crate::ipc::sf::lr::*;
 
-impl service::IService for LocationResolverManager {
+ipc_client_define_client_default!(LocationResolverManagerService);
+impl ILocationResolverManagerClient for LocationResolverManagerService {}
+
+impl service::IService for LocationResolverManagerService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("lr")
     }

--- a/src/service/mii.rs
+++ b/src/service/mii.rs
@@ -13,6 +13,9 @@ pub fn get_device_id() -> Result<CreateId> {
     service::new_service_object::<SystemSettingsService>()?.get_mii_author_id()
 }
 
+ipc_client_define_client_default!(StaticService);
+impl IStaticClient for StaticService {}
+
 impl service::IService for StaticService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("mii:e")
@@ -28,7 +31,7 @@ impl service::IService for StaticService {
 }
 
 static G_STATIC_SRV: Mutex<Option<StaticService>> = Mutex::new(None);
-static G_DB_SRV: Mutex<Option<DatabaseService>> = Mutex::new(None);
+static G_DB_SRV: Mutex<Option<MiiDatabase>> = Mutex::new(None);
 
 pub fn initialize() -> Result<()> {
     let static_service = service::new_service_object::<StaticService>()?;

--- a/src/service/ncm.rs
+++ b/src/service/ncm.rs
@@ -3,7 +3,10 @@ use crate::service;
 
 pub use crate::ipc::sf::ncm::*;
 
-impl service::IService for ContentManager {
+ipc_client_define_client_default!(ContentManagerService);
+impl IContentManagerClient for ContentManagerService {}
+
+impl service::IService for ContentManagerService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("ncm")
     }

--- a/src/service/nfp.rs
+++ b/src/service/nfp.rs
@@ -5,13 +5,13 @@ use crate::service;
 pub use crate::ipc::sf::nfp::*;
 
 ipc_client_define_client_default!(UserManagerService);
-impl IUserManagerServiceClient for UserManagerService {}
+impl IUserManagerClient for UserManagerService {}
 
 ipc_client_define_client_default!(DebugManagerService);
-impl IDebugManagerServiceClient for DebugManagerService {}
+impl IDebugManagerClient for DebugManagerService {}
 
 ipc_client_define_client_default!(SystemManagerService);
-impl ISystemManagerServiceClient for SystemManagerService {}
+impl ISystemManagerClient for SystemManagerService {}
 
 impl service::IService for UserManagerService {
     fn get_name() -> sm::ServiceName {

--- a/src/service/pm.rs
+++ b/src/service/pm.rs
@@ -4,7 +4,10 @@ use crate::service;
 
 pub use crate::ipc::sf::pm::*;
 
-impl service::IService for InformationInterface {
+ipc_client_define_client_default!(InformationInterfaceService);
+impl IInformationInterfaceClient for InformationInterfaceService {}
+
+impl service::IService for InformationInterfaceService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("pm:info")
     }
@@ -18,7 +21,10 @@ impl service::IService for InformationInterface {
     }
 }
 
-impl service::IService for DebugMonitorInterface {
+ipc_client_define_client_default!(DebugMonitorInterfaceService);
+impl IDebugMonitorInterfaceClient for DebugMonitorInterfaceService {}
+
+impl service::IService for DebugMonitorInterfaceService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("pm:dmnt")
     }

--- a/src/service/psc.rs
+++ b/src/service/psc.rs
@@ -4,6 +4,9 @@ use crate::service;
 
 pub use crate::ipc::sf::psc::*;
 
+ipc_client_define_client_default!(PmService);
+impl IPmClient for PmService {}
+
 impl service::IService for PmService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("psc:m")

--- a/src/service/usb/hs.rs
+++ b/src/service/usb/hs.rs
@@ -4,7 +4,10 @@ use crate::service;
 
 pub use crate::ipc::sf::usb::hs::*;
 
-impl service::IService for ClientRootSession {
+ipc_client_define_client_default!(ClientRootSessionService);
+impl IClientRootSessionClient for ClientRootSessionService {}
+
+impl service::IService for ClientRootSessionService {
     fn get_name() -> sm::ServiceName {
         sm::ServiceName::new("usb:hs")
     }


### PR DESCRIPTION
The exception is for HOSBinderDriver as that can be received from `ApplicationDisplay::get_relay_service`