### PR TITLE
Fix underconstrained type on `nx::sf::Buffer`.

### DIFF
--- a/nx-derive/src/ipc_traits.rs
+++ b/nx-derive/src/ipc_traits.rs
@@ -76,7 +76,7 @@ pub fn ipc_trait(_args: TokenStream, ipc_trait: TokenStream) -> syn::Result<Toke
                     Ok(Self { session: ::nx::ipc::sf::Session::from(object_info)})
                 }
             }
-            impl ::nx::ipc::server::RequestCommandParameter<#name> for #name {
+            impl ::nx::ipc::server::RequestCommandParameter<'_, #name> for #name {
                 fn after_request_read(_ctx: &mut ::nx::ipc::server::ServerContext) -> ::nx::result::Result<Self> {
                     use ::nx::result::ResultBase;
                     // TODO: determine if we need to do this, since this is a server side operation of a client object?

--- a/nx-derive/src/lib.rs
+++ b/nx-derive/src/lib.rs
@@ -26,8 +26,8 @@ pub fn derive_request(input: TokenStream) -> TokenStream {
             }
         }
 
-        impl ::nx::ipc::server::RequestCommandParameter<#name> for #name {
-            fn after_request_read(ctx: &mut ::nx::ipc::server::ServerContext) -> ::nx::result::Result<Self> {
+        impl ::nx::ipc::server::RequestCommandParameter<'_, #name> for #name {
+            fn after_request_read(ctx: &mut ::nx::ipc::server::ServerContext<'_>) -> ::nx::result::Result<Self> {
                 Ok(ctx.raw_data_walker.advance_get())
             }
         }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -31,6 +31,7 @@ impl<
     T,
 > RequestCommandParameter
     for sf::Buffer<
+        '_,
         IN,
         OUT,
         MAP_ALIAS,

--- a/src/ipc/sf/applet.rs
+++ b/src/ipc/sf/applet.rs
@@ -150,9 +150,9 @@ pub trait StorageAccessor {
     #[ipc_rid(0)]
     fn get_size(&self) -> usize;
     #[ipc_rid(10)]
-    fn write(&self, offset: usize, buf: sf::InAutoSelectBuffer<u8>);
+    fn write(&self, offset: usize, buf: sf::InAutoSelectBuffer<'_, u8>);
     #[ipc_rid(11)]
-    fn read(&self, offset: usize, buf: sf::OutAutoSelectBuffer<u8>);
+    fn read(&self, offset: usize, buf: sf::OutAutoSelectBuffer<'_, u8>);
 }
 
 #[nx_derive::ipc_trait]
@@ -405,7 +405,7 @@ pub trait AllSystemAppletProxies {
         &self,
         process_id: sf::ProcessId,
         self_process_handle: sf::CopyHandle,
-        applet_attribute: sf::InMapAliasBuffer<AppletAttribute>,
+        applet_attribute: sf::InMapAliasBuffer<'_, AppletAttribute>,
     ) -> LibraryAppletProxy;
     #[ipc_rid(300)]
     #[return_session]

--- a/src/ipc/sf/dispdrv.rs
+++ b/src/ipc/sf/dispdrv.rs
@@ -46,8 +46,8 @@ pub trait HOSBinderDriver {
         binder_handle: BinderHandle,
         transaction_id: ParcelTransactionId,
         flags: u32,
-        in_parcel: sf::InMapAliasBuffer<u8>,
-        out_parcel: sf::OutMapAliasBuffer<u8>,
+        in_parcel: sf::InMapAliasBuffer<'_, u8>,
+        out_parcel: sf::OutMapAliasBuffer<'_, u8>,
     );
     #[ipc_rid(1)]
     fn adjust_refcount(
@@ -69,7 +69,7 @@ pub trait HOSBinderDriver {
         binder_handle: BinderHandle,
         transaction_id: ParcelTransactionId,
         flags: u32,
-        in_parcel: sf::InAutoSelectBuffer<u8>,
-        out_parcel: sf::OutAutoSelectBuffer<u8>,
+        in_parcel: sf::InAutoSelectBuffer<'_, u8>,
+        out_parcel: sf::OutAutoSelectBuffer<'_, u8>,
     );
 }

--- a/src/ipc/sf/fsp.rs
+++ b/src/ipc/sf/fsp.rs
@@ -117,7 +117,7 @@ pub trait File {
         option: FileReadOption,
         offset: usize,
         size: usize,
-        out_buf: sf::OutNonSecureMapAliasBuffer<u8>,
+        out_buf: sf::OutNonSecureMapAliasBuffer<'_, u8>,
     ) -> usize;
     #[ipc_rid(1)]
     fn write(
@@ -125,7 +125,7 @@ pub trait File {
         option: FileWriteOption,
         offset: usize,
         size: usize,
-        buf: sf::InNonSecureMapAliasBuffer<u8>,
+        buf: sf::InNonSecureMapAliasBuffer<'_, u8>,
     );
     #[ipc_rid(2)]
     fn flush(&mut self);
@@ -148,8 +148,8 @@ pub trait File {
         operation_id: OperationId,
         offset: usize,
         size: usize,
-        in_buf: sf::InNonSecureMapAliasBuffer<u8>,
-        out_buf: sf::OutNonSecureMapAliasBuffer<u8>,
+        in_buf: sf::InNonSecureMapAliasBuffer<'_, u8>,
+        out_buf: sf::OutNonSecureMapAliasBuffer<'_, u8>,
     );
 }
 
@@ -157,7 +157,7 @@ pub trait File {
 #[default_client]
 pub trait Directory {
     #[ipc_rid(0)]
-    fn read(&self, out_entries: sf::OutMapAliasBuffer<DirectoryEntry>) -> u64;
+    fn read(&self, out_entries: sf::OutMapAliasBuffer<'_, DirectoryEntry>) -> u64;
     #[ipc_rid(1)]
     fn get_entry_count(&self) -> u64;
 }
@@ -170,61 +170,61 @@ pub trait FileSystem {
         &self,
         attribute: FileAttribute,
         size: usize,
-        path_buf: sf::InFixedPointerBuffer<Path>,
+        path_buf: sf::InFixedPointerBuffer<'_, Path>,
     );
     #[ipc_rid(1)]
-    fn delete_file(&self, path_buf: sf::InFixedPointerBuffer<Path>);
+    fn delete_file(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>);
     #[ipc_rid(2)]
-    fn create_directory(&self, path_buf: sf::InFixedPointerBuffer<Path>);
+    fn create_directory(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>);
     #[ipc_rid(3)]
-    fn delete_directory(&self, path_buf: sf::InFixedPointerBuffer<Path>);
+    fn delete_directory(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>);
     #[ipc_rid(4)]
-    fn delete_directory_recursively(&self, path_buf: sf::InFixedPointerBuffer<Path>);
+    fn delete_directory_recursively(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>);
     #[ipc_rid(5)]
     fn rename_file(
         &self,
-        old_path_buf: sf::InFixedPointerBuffer<Path>,
-        new_path_buf: sf::InFixedPointerBuffer<Path>,
+        old_path_buf: sf::InFixedPointerBuffer<'_, Path>,
+        new_path_buf: sf::InFixedPointerBuffer<'_, Path>,
     );
     #[ipc_rid(6)]
     fn rename_directory(
         &self,
-        old_path_buf: sf::InFixedPointerBuffer<Path>,
-        new_path_buf: sf::InFixedPointerBuffer<Path>,
+        old_path_buf: sf::InFixedPointerBuffer<'_, Path>,
+        new_path_buf: sf::InFixedPointerBuffer<'_, Path>,
     );
     #[ipc_rid(7)]
-    fn get_entry_type(&self, path_buf: sf::InFixedPointerBuffer<Path>) -> DirectoryEntryType;
+    fn get_entry_type(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>) -> DirectoryEntryType;
     #[ipc_rid(8)]
     #[return_session]
-    fn open_file(&self, mode: FileOpenMode, path_buf: sf::InFixedPointerBuffer<Path>) -> File;
+    fn open_file(&self, mode: FileOpenMode, path_buf: sf::InFixedPointerBuffer<'_, Path>) -> File;
     #[ipc_rid(9)]
     #[return_session]
     fn open_directory(
         &self,
         mode: DirectoryOpenMode,
-        path_buf: sf::InFixedPointerBuffer<Path>,
+        path_buf: sf::InFixedPointerBuffer<'_, Path>,
     ) -> Directory;
     #[ipc_rid(10)]
     fn commit(&self);
     #[ipc_rid(11)]
-    fn get_free_space_size(&self, path_buf: sf::InFixedPointerBuffer<Path>) -> usize;
+    fn get_free_space_size(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>) -> usize;
     #[ipc_rid(12)]
-    fn get_total_space_size(&self, path_buf: sf::InFixedPointerBuffer<Path>) -> usize;
+    fn get_total_space_size(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>) -> usize;
     #[ipc_rid(13)]
     #[version(version::VersionInterval::from(version::Version::new(3, 0, 0)))]
-    fn clean_directory_recursively(&self, path_buf: sf::InFixedPointerBuffer<Path>);
+    fn clean_directory_recursively(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>);
     #[ipc_rid(14)]
     #[version(version::VersionInterval::from(version::Version::new(3, 0, 0)))]
-    fn get_file_time_stamp_raw(&self, path_buf: sf::InFixedPointerBuffer<Path>)
+    fn get_file_time_stamp_raw(&self, path_buf: sf::InFixedPointerBuffer<'_, Path>)
     -> FileTimeStampRaw;
     #[ipc_rid(15)]
     #[version(version::VersionInterval::from(version::Version::new(4, 0, 0)))]
     fn query_entry(
         &self,
-        path_buf: sf::InFixedPointerBuffer<Path>,
+        path_buf: sf::InFixedPointerBuffer<'_, Path>,
         query_id: QueryId,
-        in_buf: sf::InNonSecureMapAliasBuffer<u8>,
-        out_buf: sf::OutNonSecureMapAliasBuffer<u8>,
+        in_buf: sf::InNonSecureMapAliasBuffer<'_, u8>,
+        out_buf: sf::OutNonSecureMapAliasBuffer<'_, u8>,
     );
 }
 
@@ -237,7 +237,7 @@ pub trait FileSystemProxy {
     #[return_session]
     fn open_sd_card_filesystem(&self) -> FileSystem;
     #[ipc_rid(1006)]
-    fn output_access_log_to_sd_card(&self, log_buf: sf::InMapAliasBuffer<u8>);
+    fn output_access_log_to_sd_card(&self, log_buf: sf::InMapAliasBuffer<'_, u8>);
 }
 
 pub mod srv;

--- a/src/ipc/sf/fsp/srv.rs
+++ b/src/ipc/sf/fsp/srv.rs
@@ -9,5 +9,5 @@ pub trait FileSystemProxy {
     #[ipc_rid(18)]
     fn open_sd_card_filesystem(&self) -> FileSystem;
     #[ipc_rid(1006)]
-    fn output_access_log_to_sd_card(&self, log_buf: sf::InMapAliasBuffer<u8>);
+    fn output_access_log_to_sd_card(&self, log_buf: sf::InMapAliasBuffer<'_, u8>);
 }

--- a/src/ipc/sf/hid.rs
+++ b/src/ipc/sf/hid.rs
@@ -541,7 +541,7 @@ pub trait Hid {
     fn set_supported_npad_id_type(
         &mut self,
         aruid: AppletResourceUserId,
-        npad_ids: sf::InPointerBuffer<NpadIdType>,
+        npad_ids: sf::InPointerBuffer<'_, NpadIdType>,
     );
     #[ipc_rid(103)]
     fn activate_npad(&mut self, aruid: AppletResourceUserId);

--- a/src/ipc/sf/ldr.rs
+++ b/src/ipc/sf/ldr.rs
@@ -11,11 +11,11 @@ pub trait ShellInterface {
         &self,
         program_id: ncm::ProgramId,
         args_size: u32,
-        args_buf: sf::InPointerBuffer<u8>,
+        args_buf: sf::InPointerBuffer<'_, u8>,
     );
     #[ipc_rid(0)]
     #[version(version::VersionInterval::from(version::Version::new(11, 0, 0)))]
-    fn set_program_argument(&self, program_id: ncm::ProgramId, args_buf: sf::InPointerBuffer<u8>);
+    fn set_program_argument(&self, program_id: ncm::ProgramId, args_buf: sf::InPointerBuffer<'_, u8>);
     #[ipc_rid(1)]
     fn flush_arguments(&self);
     #[ipc_rid(65000)]

--- a/src/ipc/sf/lm.rs
+++ b/src/ipc/sf/lm.rs
@@ -14,7 +14,7 @@ define_bit_enum! {
 #[default_client]
 pub trait Logger {
     #[ipc_rid(0)]
-    fn log(&self, log_buf: sf::InAutoSelectBuffer<u8>);
+    fn log(&self, log_buf: sf::InAutoSelectBuffer<'_, u8>);
     #[ipc_rid(1)]
     #[version(version::VersionInterval::from(version::Version::new(3, 0, 0)))]
     fn set_destination(&mut self, log_destination: LogDestination);

--- a/src/ipc/sf/lr.rs
+++ b/src/ipc/sf/lr.rs
@@ -6,7 +6,7 @@ use crate::version;
 #[default_client]
 pub trait LocationResolver {
     #[ipc_rid(1)]
-    fn redirect_program_path(&self, program_id: ncm::ProgramId, path_buf: sf::InPointerBuffer<u8>);
+    fn redirect_program_path(&self, program_id: ncm::ProgramId, path_buf: sf::InPointerBuffer<'_, u8>);
 }
 
 #[nx_derive::ipc_trait]
@@ -17,7 +17,7 @@ pub trait RegisteredLocationResolver {
     fn register_program_path_deprecated(
         &self,
         program_id: ncm::ProgramId,
-        path_buf: sf::InPointerBuffer<u8>,
+        path_buf: sf::InPointerBuffer<'_, u8>,
     );
     #[ipc_rid(1)]
     #[version(version::VersionInterval::from(version::Version::new(9, 0, 0)))]
@@ -25,14 +25,14 @@ pub trait RegisteredLocationResolver {
         &self,
         program_id: ncm::ProgramId,
         owner_id: ncm::ProgramId,
-        path_buf: sf::InPointerBuffer<u8>,
+        path_buf: sf::InPointerBuffer<'_, u8>,
     );
     #[ipc_rid(3)]
     #[version(version::VersionInterval::to(version::Version::new(8, 1, 1)))]
     fn redirect_program_path_deprecated(
         &self,
         program_id: ncm::ProgramId,
-        path_buf: sf::InPointerBuffer<u8>,
+        path_buf: sf::InPointerBuffer<'_, u8>,
     );
     #[ipc_rid(3)]
     #[version(version::VersionInterval::from(version::Version::new(9, 0, 0)))]
@@ -40,7 +40,7 @@ pub trait RegisteredLocationResolver {
         &self,
         program_id: ncm::ProgramId,
         owner_id: ncm::ProgramId,
-        path_buf: sf::InPointerBuffer<u8>,
+        path_buf: sf::InPointerBuffer<'_, u8>,
     );
 }
 

--- a/src/ipc/sf/mii.rs
+++ b/src/ipc/sf/mii.rs
@@ -1892,7 +1892,7 @@ pub trait MiiDatabase {
     #[ipc_rid(2)]
     fn get_count(&self, flag: SourceFlag) -> u32;
     #[ipc_rid(4)]
-    fn get_one(&self, flag: SourceFlag, out_char_infos: sf::OutMapAliasBuffer<CharInfo>) -> u32;
+    fn get_one(&self, flag: SourceFlag, out_char_infos: sf::OutMapAliasBuffer<'_, CharInfo>) -> u32;
     #[ipc_rid(6)]
     fn build_random(
         &self,

--- a/src/ipc/sf/ncm.rs
+++ b/src/ipc/sf/ncm.rs
@@ -149,9 +149,9 @@ pub struct ContentMetaInfo {
 #[default_client]
 pub trait ContentMetaDatabase {
     #[ipc_rid(0)]
-    fn set(&self, meta_key: ContentMetaKey, in_rec_buf: sf::InMapAliasBuffer<u8>);
+    fn set(&self, meta_key: ContentMetaKey, in_rec_buf: sf::InMapAliasBuffer<'_, u8>);
     #[ipc_rid(1)]
-    fn get(&self, meta_key: ContentMetaKey, out_rec_buf: sf::OutMapAliasBuffer<u8>) -> usize;
+    fn get(&self, meta_key: ContentMetaKey, out_rec_buf: sf::OutMapAliasBuffer<'_, u8>) -> usize;
     #[ipc_rid(2)]
     fn remove(&self, meta_key: ContentMetaKey);
     #[ipc_rid(3)]
@@ -159,14 +159,14 @@ pub trait ContentMetaDatabase {
     #[ipc_rid(4)]
     fn list_content_info(
         &self,
-        out_rec_buf: sf::OutMapAliasBuffer<ContentInfo>,
+        out_rec_buf: sf::OutMapAliasBuffer<'_, ContentInfo>,
         meta_key: ContentMetaKey,
         offset: u32,
     ) -> u32;
     #[ipc_rid(5)]
     fn list(
         &self,
-        out_meta_keys: sf::OutMapAliasBuffer<ContentMetaKey>,
+        out_meta_keys: sf::OutMapAliasBuffer<'_, ContentMetaKey>,
         meta_type: ContentMetaType,
         program_id: ProgramId,
         program_id_min: ProgramId,
@@ -178,13 +178,13 @@ pub trait ContentMetaDatabase {
     #[ipc_rid(7)]
     fn list_application(
         &self,
-        out_app_meta_keys: sf::OutMapAliasBuffer<ApplicationContentMetaKey>,
+        out_app_meta_keys: sf::OutMapAliasBuffer<'_, ApplicationContentMetaKey>,
         meta_type: ContentMetaType,
     ) -> (u32, u32);
     #[ipc_rid(8)]
     fn has(&self, meta_key: ContentMetaKey) -> bool;
     #[ipc_rid(9)]
-    fn has_all(&self, meta_keys_buf: sf::InMapAliasBuffer<ContentMetaKey>) -> bool;
+    fn has_all(&self, meta_keys_buf: sf::InMapAliasBuffer<'_, ContentMetaKey>) -> bool;
     #[ipc_rid(10)]
     fn get_size(&self, meta_key: ContentMetaKey) -> usize;
     #[ipc_rid(11)]
@@ -196,8 +196,8 @@ pub trait ContentMetaDatabase {
     #[ipc_rid(14)]
     fn lookup_orphan_content(
         &self,
-        content_ids_buf: sf::InMapAliasBuffer<ContentId>,
-        out_orphaned_buf: sf::OutMapAliasBuffer<bool>,
+        content_ids_buf: sf::InMapAliasBuffer<'_, ContentId>,
+        out_orphaned_buf: sf::OutMapAliasBuffer<'_, bool>,
     );
     #[ipc_rid(15)]
     fn commit(&self);
@@ -206,7 +206,7 @@ pub trait ContentMetaDatabase {
     #[ipc_rid(17)]
     fn list_content_meta_info(
         &self,
-        out_meta_infos: sf::OutMapAliasBuffer<ContentMetaInfo>,
+        out_meta_infos: sf::OutMapAliasBuffer<'_, ContentMetaInfo>,
         meta_key: ContentMetaKey,
         offset: u32,
     ) -> u32;

--- a/src/ipc/sf/nfp.rs
+++ b/src/ipc/sf/nfp.rs
@@ -220,12 +220,12 @@ pub trait User {
         &self,
         aruid: applet::AppletResourceUserId,
         process_id: sf::ProcessId,
-        mcu_data: sf::InMapAliasBuffer<McuVersionData>,
+        mcu_data: sf::InMapAliasBuffer<'_, McuVersionData>,
     );
     #[ipc_rid(1)]
     fn finalize(&self);
     #[ipc_rid(2)]
-    fn list_devices(&self, out_devices: sf::OutPointerBuffer<DeviceHandle>) -> u32;
+    fn list_devices(&self, out_devices: sf::OutPointerBuffer<'_, DeviceHandle>) -> u32;
     #[ipc_rid(3)]
     fn start_detection(&self, device_handle: DeviceHandle);
     #[ipc_rid(4)]
@@ -240,10 +240,10 @@ pub trait User {
     fn get_application_area(
         &self,
         device_handle: DeviceHandle,
-        out_data: sf::OutMapAliasBuffer<u8>,
+        out_data: sf::OutMapAliasBuffer<'_, u8>,
     ) -> u32;
     #[ipc_rid(9)]
-    fn set_application_area(&self, device_handle: DeviceHandle, data: sf::InMapAliasBuffer<u8>);
+    fn set_application_area(&self, device_handle: DeviceHandle, data: sf::InMapAliasBuffer<'_, u8>);
     #[ipc_rid(10)]
     fn flush(&self, device_handle: DeviceHandle);
     #[ipc_rid(11)]
@@ -253,31 +253,31 @@ pub trait User {
         &self,
         device_handle: DeviceHandle,
         access_id: AccessId,
-        data: sf::InMapAliasBuffer<u8>,
+        data: sf::InMapAliasBuffer<'_, u8>,
     );
     #[ipc_rid(13)]
     fn get_tag_info(
         &self,
         device_handle: DeviceHandle,
-        out_tag_info: sf::OutFixedPointerBuffer<TagInfo>,
+        out_tag_info: sf::OutFixedPointerBuffer<'_, TagInfo>,
     );
     #[ipc_rid(14)]
     fn get_register_info(
         &self,
         device_handle: DeviceHandle,
-        out_register_info: sf::OutFixedPointerBuffer<RegisterInfo>,
+        out_register_info: sf::OutFixedPointerBuffer<'_, RegisterInfo>,
     );
     #[ipc_rid(15)]
     fn get_common_info(
         &self,
         device_handle: DeviceHandle,
-        out_common_info: sf::OutFixedPointerBuffer<CommonInfo>,
+        out_common_info: sf::OutFixedPointerBuffer<'_, CommonInfo>,
     );
     #[ipc_rid(16)]
     fn get_model_info(
         &self,
         device_handle: DeviceHandle,
-        out_model_info: sf::OutFixedPointerBuffer<ModelInfo>,
+        out_model_info: sf::OutFixedPointerBuffer<'_, ModelInfo>,
     );
     #[ipc_rid(17)]
     fn attach_activate_event(&self, device_handle: DeviceHandle) -> sf::CopyHandle;
@@ -300,7 +300,7 @@ pub trait User {
         &self,
         device_handle: DeviceHandle,
         access_id: AccessId,
-        data: sf::InMapAliasBuffer<u8>,
+        data: sf::InMapAliasBuffer<'_, u8>,
     );
 }
 
@@ -319,12 +319,12 @@ pub trait System {
         &self,
         aruid: applet::AppletResourceUserId,
         process_id: sf::ProcessId,
-        mcu_data: sf::InMapAliasBuffer<McuVersionData>,
+        mcu_data: sf::InMapAliasBuffer<'_, McuVersionData>,
     );
     #[ipc_rid(1)]
     fn finalize(&self);
     #[ipc_rid(2)]
-    fn list_devices(&self, out_devices: sf::OutPointerBuffer<DeviceHandle>) -> u32;
+    fn list_devices(&self, out_devices: sf::OutPointerBuffer<'_, DeviceHandle>) -> u32;
     #[ipc_rid(3)]
     fn start_detection(&self, device_handle: DeviceHandle);
     #[ipc_rid(4)]
@@ -341,25 +341,25 @@ pub trait System {
     fn get_tag_info(
         &self,
         device_handle: DeviceHandle,
-        out_tag_info: sf::OutFixedPointerBuffer<TagInfo>,
+        out_tag_info: sf::OutFixedPointerBuffer<'_, TagInfo>,
     );
     #[ipc_rid(14)]
     fn get_register_info(
         &self,
         device_handle: DeviceHandle,
-        out_register_info: sf::OutFixedPointerBuffer<RegisterInfo>,
+        out_register_info: sf::OutFixedPointerBuffer<'_, RegisterInfo>,
     );
     #[ipc_rid(15)]
     fn get_common_info(
         &self,
         device_handle: DeviceHandle,
-        out_common_info: sf::OutFixedPointerBuffer<CommonInfo>,
+        out_common_info: sf::OutFixedPointerBuffer<'_, CommonInfo>,
     );
     #[ipc_rid(16)]
     fn get_model_info(
         &self,
         device_handle: DeviceHandle,
-        out_model_info: sf::OutFixedPointerBuffer<ModelInfo>,
+        out_model_info: sf::OutFixedPointerBuffer<'_, ModelInfo>,
     );
     #[ipc_rid(17)]
     fn attach_activate_event(&self, device_handle: DeviceHandle) -> sf::CopyHandle;
@@ -379,19 +379,19 @@ pub trait System {
     fn get_admin_info(
         &self,
         device_handle: DeviceHandle,
-        out_admin_info: sf::OutFixedPointerBuffer<AdminInfo>,
+        out_admin_info: sf::OutFixedPointerBuffer<'_, AdminInfo>,
     );
     #[ipc_rid(102)]
     fn get_register_info_private(
         &self,
         device_handle: DeviceHandle,
-        out_register_info_private: sf::OutFixedPointerBuffer<RegisterInfoPrivate>,
+        out_register_info_private: sf::OutFixedPointerBuffer<'_, RegisterInfoPrivate>,
     );
     #[ipc_rid(103)]
     fn set_register_info_private(
         &self,
         device_handle: DeviceHandle,
-        register_info_private: sf::InFixedPointerBuffer<RegisterInfoPrivate>,
+        register_info_private: sf::InFixedPointerBuffer<'_, RegisterInfoPrivate>,
     );
     #[ipc_rid(104)]
     fn delete_register_info(&self, device_handle: DeviceHandle);
@@ -416,12 +416,12 @@ pub trait Debug {
         &self,
         aruid: applet::AppletResourceUserId,
         process_id: sf::ProcessId,
-        mcu_data: sf::InMapAliasBuffer<McuVersionData>,
+        mcu_data: sf::InMapAliasBuffer<'_, McuVersionData>,
     );
     #[ipc_rid(1)]
     fn finalize(&self);
     #[ipc_rid(2)]
-    fn list_devices(&self, out_devices: sf::OutPointerBuffer<DeviceHandle>) -> u32;
+    fn list_devices(&self, out_devices: sf::OutPointerBuffer<'_, DeviceHandle>) -> u32;
     #[ipc_rid(3)]
     fn start_detection(&self, device_handle: DeviceHandle);
     #[ipc_rid(4)]
@@ -436,10 +436,10 @@ pub trait Debug {
     fn get_application_area(
         &self,
         device_handle: DeviceHandle,
-        out_data: sf::OutMapAliasBuffer<u8>,
+        out_data: sf::OutMapAliasBuffer<'_, u8>,
     ) -> u32;
     #[ipc_rid(9)]
-    fn set_application_area(&self, device_handle: DeviceHandle, data: sf::InMapAliasBuffer<u8>);
+    fn set_application_area(&self, device_handle: DeviceHandle, data: sf::InMapAliasBuffer<'_, u8>);
     #[ipc_rid(10)]
     fn flush(&self, device_handle: DeviceHandle);
     #[ipc_rid(11)]
@@ -449,31 +449,31 @@ pub trait Debug {
         &self,
         device_handle: DeviceHandle,
         access_id: AccessId,
-        data: sf::InMapAliasBuffer<u8>,
+        data: sf::InMapAliasBuffer<'_, u8>,
     );
     #[ipc_rid(13)]
     fn get_tag_info(
         &self,
         device_handle: DeviceHandle,
-        out_tag_info: sf::OutFixedPointerBuffer<TagInfo>,
+        out_tag_info: sf::OutFixedPointerBuffer<'_, TagInfo>,
     );
     #[ipc_rid(14)]
     fn get_register_info(
         &self,
         device_handle: DeviceHandle,
-        out_register_info: sf::OutFixedPointerBuffer<RegisterInfo>,
+        out_register_info: sf::OutFixedPointerBuffer<'_, RegisterInfo>,
     );
     #[ipc_rid(15)]
     fn get_common_info(
         &self,
         device_handle: DeviceHandle,
-        out_common_info: sf::OutFixedPointerBuffer<CommonInfo>,
+        out_common_info: sf::OutFixedPointerBuffer<'_, CommonInfo>,
     );
     #[ipc_rid(16)]
     fn get_model_info(
         &self,
         device_handle: DeviceHandle,
-        out_model_info: sf::OutFixedPointerBuffer<ModelInfo>,
+        out_model_info: sf::OutFixedPointerBuffer<'_, ModelInfo>,
     );
     #[ipc_rid(17)]
     fn attach_activate_event(&self, device_handle: DeviceHandle) -> sf::CopyHandle;
@@ -496,7 +496,7 @@ pub trait Debug {
         &self,
         device_handle: DeviceHandle,
         access_id: AccessId,
-        data: sf::InMapAliasBuffer<u8>,
+        data: sf::InMapAliasBuffer<'_, u8>,
     );
     #[ipc_rid(100)]
     fn format(&self, device_handle: DeviceHandle);
@@ -504,19 +504,19 @@ pub trait Debug {
     fn get_admin_info(
         &self,
         device_handle: DeviceHandle,
-        out_admin_info: sf::OutFixedPointerBuffer<AdminInfo>,
+        out_admin_info: sf::OutFixedPointerBuffer<'_, AdminInfo>,
     );
     #[ipc_rid(102)]
     fn get_register_info_private(
         &self,
         device_handle: DeviceHandle,
-        out_register_info_private: sf::OutFixedPointerBuffer<RegisterInfoPrivate>,
+        out_register_info_private: sf::OutFixedPointerBuffer<'_, RegisterInfoPrivate>,
     );
     #[ipc_rid(103)]
     fn set_register_info_private(
         &self,
         device_handle: DeviceHandle,
-        register_info_private: sf::InFixedPointerBuffer<RegisterInfoPrivate>,
+        register_info_private: sf::InFixedPointerBuffer<'_, RegisterInfoPrivate>,
     );
     #[ipc_rid(104)]
     fn delete_register_info(&self, device_handle: DeviceHandle);
@@ -525,9 +525,9 @@ pub trait Debug {
     #[ipc_rid(106)]
     fn exists_application_area(&self, device_handle: DeviceHandle) -> bool;
     #[ipc_rid(200)]
-    fn get_all(&self, device_handle: DeviceHandle, out_data: sf::OutFixedPointerBuffer<NfpData>);
+    fn get_all(&self, device_handle: DeviceHandle, out_data: sf::OutFixedPointerBuffer<'_, NfpData>);
     #[ipc_rid(201)]
-    fn set_all(&self, device_handle: DeviceHandle, data: sf::InFixedPointerBuffer<NfpData>);
+    fn set_all(&self, device_handle: DeviceHandle, data: sf::InFixedPointerBuffer<'_, NfpData>);
     #[ipc_rid(202)]
     fn flush_debug(&self, device_handle: DeviceHandle);
     #[ipc_rid(203)]
@@ -536,16 +536,16 @@ pub trait Debug {
     fn read_backup_data(
         &self,
         device_handle: DeviceHandle,
-        out_buf: sf::OutMapAliasBuffer<u8>,
+        out_buf: sf::OutMapAliasBuffer<'_, u8>,
     ) -> u32;
     #[ipc_rid(205)]
-    fn write_backup_data(&self, device_handle: DeviceHandle, buf: sf::InMapAliasBuffer<u8>);
+    fn write_backup_data(&self, device_handle: DeviceHandle, buf: sf::InMapAliasBuffer<'_, u8>);
     #[ipc_rid(206)]
     fn write_ntf(
         &self,
         device_handle: DeviceHandle,
         write_type: WriteType,
-        buf: sf::InMapAliasBuffer<u8>,
+        buf: sf::InMapAliasBuffer<'_, u8>,
     );
 }
 

--- a/src/ipc/sf/nv.rs
+++ b/src/ipc/sf/nv.rs
@@ -45,14 +45,14 @@ pub type Fd = u32;
 #[nx_derive::ipc_trait]
 pub trait NvDrv {
     #[ipc_rid(0)]
-    fn open(&self, path: sf::InMapAliasBuffer<u8>) -> (Fd, ErrorCode);
+    fn open(&self, path: sf::InMapAliasBuffer<'_, u8>) -> (Fd, ErrorCode);
     #[ipc_rid(1)]
     fn ioctl(
         &self,
         fd: Fd,
         id: IoctlId,
-        in_buf: sf::InAutoSelectBuffer<u8>,
-        out_buf: sf::OutAutoSelectBuffer<u8>,
+        in_buf: sf::InAutoSelectBuffer<'_, u8>,
+        out_buf: sf::OutAutoSelectBuffer<'_, u8>,
     ) -> ErrorCode;
     #[ipc_rid(2)]
     fn close(&self, fd: Fd) -> ErrorCode;

--- a/src/ipc/sf/psc.rs
+++ b/src/ipc/sf/psc.rs
@@ -29,7 +29,7 @@ pub trait PmModule {
     fn initialize(
         &self,
         id: ModuleId,
-        dependencies: sf::InMapAliasBuffer<ModuleId>,
+        dependencies: sf::InMapAliasBuffer<'_, ModuleId>,
     ) -> sf::CopyHandle;
     #[ipc_rid(1)]
     fn get_request(&self) -> (State, u32);

--- a/src/ipc/sf/set.rs
+++ b/src/ipc/sf/set.rs
@@ -26,10 +26,10 @@ const_assert!(core::mem::size_of::<FirmwareVersion>() == 0x100);
 #[nx_derive::ipc_trait]
 pub trait SystemSettings {
     #[ipc_rid(3)]
-    fn get_firmware_version(&self, out_version: sf::OutFixedPointerBuffer<FirmwareVersion>);
+    fn get_firmware_version(&self, out_version: sf::OutFixedPointerBuffer<'_, FirmwareVersion>);
     #[ipc_rid(4)]
     #[version(version::VersionInterval::from(version::Version::new(3, 0, 0)))]
-    fn get_firmware_version_2(&self, out_version: sf::OutFixedPointerBuffer<FirmwareVersion>);
+    fn get_firmware_version_2(&self, out_version: sf::OutFixedPointerBuffer<'_, FirmwareVersion>);
     #[ipc_rid(90)]
     fn get_mii_author_id(&self) -> mii::CreateId;
 }

--- a/src/ipc/sf/spl.rs
+++ b/src/ipc/sf/spl.rs
@@ -3,5 +3,5 @@ use crate::ipc::sf;
 #[nx_derive::ipc_trait]
 pub trait Random {
     #[ipc_rid(0)]
-    fn generate_random_bytes(&self, out_buf: sf::OutMapAliasBuffer<u8>);
+    fn generate_random_bytes(&self, out_buf: sf::OutMapAliasBuffer<'_, u8>);
 }

--- a/src/ipc/sf/usb/hs.rs
+++ b/src/ipc/sf/usb/hs.rs
@@ -99,13 +99,13 @@ const_assert!(core::mem::size_of::<XferReport>() == 0x18);
 pub trait ClientEpSession {
     #[ipc_rid(0)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]
-    fn submit_out_request(&self, size: u32, unk: u32, buf: sf::InMapAliasBuffer<u8>) -> u32;
+    fn submit_out_request(&self, size: u32, unk: u32, buf: sf::InMapAliasBuffer<'_, u8>) -> u32;
     #[ipc_rid(0)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
     fn re_open(&self);
     #[ipc_rid(1)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]
-    fn submit_in_request(&self, size: u32, unk: u32, out_buf: sf::OutMapAliasBuffer<u8>) -> u32;
+    fn submit_in_request(&self, size: u32, unk: u32, out_buf: sf::OutMapAliasBuffer<'_, u8>) -> u32;
     #[ipc_rid(1)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
     fn close(&self);
@@ -132,14 +132,14 @@ pub trait ClientEpSession {
     fn get_xfer_report_deprecated(
         &self,
         count: u32,
-        out_reports_buf: sf::OutMapAliasBuffer<XferReport>,
+        out_reports_buf: sf::OutMapAliasBuffer<'_, XferReport>,
     ) -> u32;
     #[ipc_rid(5)]
     #[version(version::VersionInterval::from(version::Version::new(3, 0, 0)))]
     fn get_xfer_report(
         &self,
         count: u32,
-        out_reports_buf: sf::OutAutoSelectBuffer<XferReport>,
+        out_reports_buf: sf::OutAutoSelectBuffer<'_, XferReport>,
     ) -> u32;
     #[ipc_rid(6)]
     #[version(version::VersionInterval::from_to(
@@ -153,7 +153,7 @@ pub trait ClientEpSession {
         unk_2: u32,
         buf_addr: u64,
         unk_3: u64,
-        urb_sizes_buf: sf::InMapAliasBuffer<u32>,
+        urb_sizes_buf: sf::InMapAliasBuffer<'_, u32>,
     ) -> u32;
     #[ipc_rid(6)]
     #[version(version::VersionInterval::from(version::Version::new(3, 0, 0)))]
@@ -164,7 +164,7 @@ pub trait ClientEpSession {
         unk_2: u32,
         buf_addr: u64,
         unk_3: u64,
-        urb_sizes_buf: sf::InAutoSelectBuffer<u32>,
+        urb_sizes_buf: sf::InAutoSelectBuffer<'_, u32>,
     ) -> u32;
     #[ipc_rid(7)]
     #[version(version::VersionInterval::from(version::Version::new(4, 0, 0)))]
@@ -180,14 +180,14 @@ pub trait ClientIfSession {
     #[ipc_rid(0)]
     fn get_state_change_event(&self) -> sf::CopyHandle;
     #[ipc_rid(1)]
-    fn set_interface(&self, unk: u8, profile_buf: sf::InMapAliasBuffer<InterfaceProfile>);
+    fn set_interface(&self, unk: u8, profile_buf: sf::InMapAliasBuffer<'_, InterfaceProfile>);
     #[ipc_rid(2)]
-    fn get_interface(&self, out_profile_buf: sf::OutMapAliasBuffer<InterfaceProfile>);
+    fn get_interface(&self, out_profile_buf: sf::OutMapAliasBuffer<'_, InterfaceProfile>);
     #[ipc_rid(3)]
     fn get_alternate_interface(
         &self,
         unk: u8,
-        out_profile_buf: sf::OutMapAliasBuffer<InterfaceProfile>,
+        out_profile_buf: sf::OutMapAliasBuffer<'_, InterfaceProfile>,
     );
     #[ipc_rid(5)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]
@@ -216,7 +216,7 @@ pub trait ClientIfSession {
         idx: u16,
         length: u16,
         timeout_ms: u32,
-        out_buf: sf::OutMapAliasBuffer<u8>,
+        out_buf: sf::OutMapAliasBuffer<'_, u8>,
     ) -> u32;
     #[ipc_rid(6)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
@@ -231,11 +231,11 @@ pub trait ClientIfSession {
         idx: u16,
         length: u16,
         timeout_ms: u32,
-        buf: sf::InMapAliasBuffer<u8>,
+        buf: sf::InMapAliasBuffer<'_, u8>,
     ) -> u32;
     #[ipc_rid(7)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
-    fn get_ctrl_xfer_report(&self, out_report_buf: sf::OutMapAliasBuffer<XferReport>);
+    fn get_ctrl_xfer_report(&self, out_report_buf: sf::OutMapAliasBuffer<'_, XferReport>);
     #[ipc_rid(8)]
     fn reset_device(&self, unk: u32);
     #[ipc_rid(4)]
@@ -270,40 +270,40 @@ pub trait ClientRootSession {
     fn query_all_interfaces_deprecated(
         &self,
         filter: DeviceFilter,
-        out_intfs: sf::OutMapAliasBuffer<InterfaceQueryOutput>,
+        out_intfs: sf::OutMapAliasBuffer<'_, InterfaceQueryOutput>,
     ) -> u32;
     #[ipc_rid(1)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
     fn query_all_interfaces(
         &self,
         filter: DeviceFilter,
-        out_intfs: sf::OutMapAliasBuffer<InterfaceQueryOutput>,
+        out_intfs: sf::OutMapAliasBuffer<'_, InterfaceQueryOutput>,
     ) -> u32;
     #[ipc_rid(1)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]
     fn query_available_interfaces_deprecated(
         &self,
         filter: DeviceFilter,
-        out_intfs: sf::OutMapAliasBuffer<InterfaceQueryOutput>,
+        out_intfs: sf::OutMapAliasBuffer<'_, InterfaceQueryOutput>,
     ) -> u32;
     #[ipc_rid(2)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
     fn query_available_interfaces(
         &self,
         filter: DeviceFilter,
-        out_intfs: sf::OutMapAliasBuffer<InterfaceQueryOutput>,
+        out_intfs: sf::OutMapAliasBuffer<'_, InterfaceQueryOutput>,
     ) -> u32;
     #[ipc_rid(2)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]
     fn query_acquired_interfaces_deprecated(
         &self,
-        out_intfs: sf::OutMapAliasBuffer<InterfaceQueryOutput>,
+        out_intfs: sf::OutMapAliasBuffer<'_, InterfaceQueryOutput>,
     ) -> u32;
     #[ipc_rid(3)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
     fn query_acquired_interfaces(
         &self,
-        out_intfs: sf::OutMapAliasBuffer<InterfaceQueryOutput>,
+        out_intfs: sf::OutMapAliasBuffer<'_, InterfaceQueryOutput>,
     ) -> u32;
     #[ipc_rid(3)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]
@@ -336,15 +336,15 @@ pub trait ClientRootSession {
     fn acquire_usb_if_deprecated(
         &self,
         id: u32,
-        out_profile_buf: sf::OutMapAliasBuffer<InterfaceProfile>,
+        out_profile_buf: sf::OutMapAliasBuffer<'_, InterfaceProfile>,
     ) -> ClientIfSession;
     #[ipc_rid(7)]
     #[version(version::VersionInterval::from(version::Version::new(2, 0, 0)))]
     fn acquire_usb_if(
         &self,
         id: u32,
-        out_info_buf: sf::OutMapAliasBuffer<InterfaceInfo>,
-        out_profile_buf: sf::OutMapAliasBuffer<InterfaceProfile>,
+        out_info_buf: sf::OutMapAliasBuffer<'_, InterfaceInfo>,
+        out_profile_buf: sf::OutMapAliasBuffer<'_, InterfaceProfile>,
     ) -> ClientIfSession;
     #[ipc_rid(7)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]
@@ -353,7 +353,7 @@ pub trait ClientRootSession {
         unk_1: u8,
         unk_2: bool,
         unk_maybe_id: u32,
-        out_desc_buf: sf::OutMapAliasBuffer<u8>,
+        out_desc_buf: sf::OutMapAliasBuffer<'_, u8>,
     ) -> u32;
     #[ipc_rid(8)]
     #[version(version::VersionInterval::to(version::Version::new(1, 0, 0)))]

--- a/src/ipc/sf/vi.rs
+++ b/src/ipc/sf/vi.rs
@@ -106,7 +106,7 @@ pub trait ApplicationDisplay {
         name: DisplayName,
         id: LayerId,
         aruid: AppletResourceUserId,
-        out_native_window: sf::OutMapAliasBuffer<u8>,
+        out_native_window: sf::OutMapAliasBuffer<'_, u8>,
     ) -> usize;
     #[ipc_rid(2021)]
     fn set_scaling_mode(&mut self, scaling_mode: ScalingMode, layer_id: LayerId);
@@ -115,7 +115,7 @@ pub trait ApplicationDisplay {
         &mut self,
         flags: LayerFlags,
         display_id: DisplayId,
-        out_native_window: sf::OutMapAliasBuffer<u8>,
+        out_native_window: sf::OutMapAliasBuffer<'_, u8>,
     ) -> (LayerId, usize);
     #[ipc_rid(2031)]
     fn destroy_stray_layer(&mut self, id: LayerId);

--- a/src/macros/ipc/client.rs
+++ b/src/macros/ipc/client.rs
@@ -59,7 +59,7 @@ macro_rules! ipc_sf_define_default_client_for_interface {
                     Ok(Self { session: $crate::ipc::sf::Session::from(object_info)})
                 }
             }
-            impl $crate::ipc::server::RequestCommandParameter<$t> for $t {
+            impl $crate::ipc::server::RequestCommandParameter<'_, $t> for $t {
                 fn after_request_read(_ctx: &mut $crate::ipc::server::ServerContext) -> $crate::result::Result<Self> {
                     use $crate::result::ResultBase;
                     // TODO: determine if we need to do this, since this is a server side operation of a client object?

--- a/src/macros/ipc/sf.rs
+++ b/src/macros/ipc/sf.rs
@@ -195,7 +195,7 @@ macro_rules! server_mark_request_command_parameters_types_as_copy {
     ($($t:ty),*) => {
         $(
         //const_assert!($t::is_pod());
-        impl $crate::ipc::server::RequestCommandParameter<$t> for $t {
+        impl $crate::ipc::server::RequestCommandParameter<'_,$t> for $t {
             fn after_request_read(ctx: &mut $crate::ipc::server::ServerContext) -> $crate::result::Result<Self> {
                 Ok(ctx.raw_data_walker.advance_get())
             }
@@ -231,7 +231,7 @@ api_mark_request_command_parameters_types_as_copy!(
     bool, u8, i8, u16, i16, u32, i32, u64, i64, usize, isize, u128, i128, f32, f64
 );
 
-impl<T: Copy, const N: usize> crate::ipc::server::RequestCommandParameter<[T; N]> for [T; N] {
+impl<T: Copy, const N: usize> crate::ipc::server::RequestCommandParameter<'_,[T; N]> for [T; N] {
     fn after_request_read(
         ctx: &mut crate::ipc::server::ServerContext,
     ) -> crate::result::Result<Self> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -159,7 +159,7 @@ pub struct ArrayString<const S: usize> {
     c_str: [u8; S],
 }
 
-impl<const S: usize> crate::ipc::server::RequestCommandParameter<ArrayString<S>>
+impl<const S: usize> crate::ipc::server::RequestCommandParameter<'_,ArrayString<S>>
     for ArrayString<S>
 {
     fn after_request_read(ctx: &mut crate::ipc::server::ServerContext) -> Result<Self> {
@@ -400,7 +400,7 @@ pub struct ArrayWideString<const S: usize> {
     c_wstr: [u16; S],
 }
 
-impl<const S: usize> crate::ipc::server::RequestCommandParameter<ArrayWideString<S>>
+impl<const S: usize> crate::ipc::server::RequestCommandParameter<'_,ArrayWideString<S>>
     for ArrayWideString<S>
 {
     fn after_request_read(ctx: &mut crate::ipc::server::ServerContext) -> Result<Self> {


### PR DESCRIPTION
The buffer type previously didn't take into account the lifetime of the referenced data, so it is easy to cause use after free in API clients or accidentally hold on to buffer references too long in server implementations.

This gives a lifetime bound to the buffer type so it (hopefully) doesn't outlive the source data or escape the server function.