### PR TITLE
Update embedded-graphics-core to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ optional = true
 default-features = false
 
 [dependencies.embedded-graphics-core]
-version = "0.3.3"
+version = "0.4.1"
 optional = true
 
 [dependencies.line_drawing]


### PR DESCRIPTION
I have successfully gotten Ratatui/Mousefood running on the Nintendo Switch: https://github.com/sermuns/ratatui-on-nintendo-switch/

I can not thank you enough for this library, so amazing!

Mousefood does however require `embedded-graphics` 0.4.1, so my example repo depends on my fork of `nx` where that dependency has been updated.

I don't see any reason why this change can't be merged, but please let me know if we need an older version of `embedded-graphics`.
