### PR TITLE
fix: patch build issues with `unwinding`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,7 @@ name = "nx"
 version = "0.5.0"
 authors = ["XorTroll", "Pantsman0"]
 edition = "2024"
-include = [
-    "src",
-    "nx_derive"
-]
+include = ["src", "nx_derive"]
 
 [features]
 default = []
@@ -29,7 +26,7 @@ mii = ["services"]
 
 [dependencies]
 paste = "1.0"
-logpacket = { git = "https://github.com/aarch64-switch-rs/logpacket", tag = "0.1.0"}
+logpacket = { git = "https://github.com/aarch64-switch-rs/logpacket", tag = "0.1.0" }
 arrayvec = { version = "0.7.6", default-features = false }
 static_assertions = "1.1.0"
 lock_api = { version = "0.4.12", features = ["nightly"] }
@@ -78,18 +75,19 @@ default-features = false
 features = ["libm"]
 
 [dependencies.unwinding]
-version = "0.2.8"
+# FIXME(unwinding): remove this once `unwinding` gets a new release.
+git = "https://github.com/dybucc/unwinding.git"
+rev = "a3d5284ba54b4071a422592174f649bd1045a0b7"
 default-features = false
 features = ["unwinder", "panic", "fde-custom", "personality"]
 
 [dependencies.linked_list_allocator]
 version = "0.10.5"
 default-features = false
-features = [ "const_mut_refs", "alloc_ref", "use_spin" ]
+features = ["const_mut_refs", "alloc_ref", "use_spin"]
 
 [dependencies.rand]
 optional = true
 version = "0.9.2"
 default-features = false
 features = ["alloc"]
-


### PR DESCRIPTION
The `unwinding` crate relies on compiler intrinsics that are not stable. At present, release 0.2.8,
on which the `nx` crate depends, is broken because the return value of an intrinsic changed. This
affects users of `cargo-nx` as the build fails.

Upstream `unwinding` has already fixed this, but there's yet to be a new release. Meanwhile, this
patch should do the trick. The dependency was changed to a fork that cherry picked only the fix
commit on top of the 0.2.8 release, so none of the upstream changes post-0.2.8 (except the fix) are
included.

Note this does not use the `[patch]` section of `Cargo.toml` because that does not transitively
apply to projects that depend on `nx`, like all new `cargo-nx`-based projects. That's why a
dependency override was not possible. Still, a `FIXME` comment was left once a new `unwinding`
release is published on crates.io.
