### PR TITLE
Pin `unwinding` version to a specific commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,12 @@ default-features = false
 features = ["libm"]
 
 [dependencies.unwinding]
-version = "0.2.8"
+#version = "0.2.8"
 default-features = false
 features = ["unwinder", "panic", "fde-custom", "personality"]
+# use pinned git commit until 0.2.9 is released
+git = "https://github.com/nbdd0121/unwinding"
+rev = "e432817afbea4c13f011f63b882486192d15f22b"
 
 [dependencies.linked_list_allocator]
 version = "0.10.5"


### PR DESCRIPTION
due to change in `catch_unwind` intrinsic's signature.

This is a duplicate of https://github.com/aarch64-switch-rs/nx/pull/61, but I tested that the other changes don't break our builds so we can use the original crate at a locked commit.